### PR TITLE
refactor: use pydantic models in gen recursive; moved build_ancestors…

### DIFF
--- a/src/init_migration/generate_pipeline.py
+++ b/src/init_migration/generate_pipeline.py
@@ -344,22 +344,31 @@ class GeneratePipeline:
 
             response.status = GeneratorStatus(status=Status.SUCCESS)
 
-            # Ensure placeholder stubs exist for every ancestor level (state, county,
-            # etc.) before processing the leaf.  Failures here are non-fatal so that
-            # a transient I/O error does not abort the main generation work.
-            ancestor_results = ensure_ancestor_stubs(
-                self.data.ocdid.raw_ocdid,
-                self.division_output_dir,
-                self.jurisdiction_output_dir,
-            )
-            logger.info(
-                "Ancestor stub check complete",
-                extra={
-                    "ocdid": self.data.ocdid.raw_ocdid,
-                    "ancestor_count": len(ancestor_results),
-                    "created": sum(1 for r in ancestor_results if r["action"] == "created"),
-                },
-            )
+            # Once the leaf Division/Jurisdiction is generated, ensure placeholder
+            # stubs exist for every ancestor level (state, county, etc.).
+            # Failures here are non-fatal — a transient I/O error must not abort
+            # a successful leaf generation.
+            try:
+                ancestor_results = ensure_ancestor_stubs(
+                    self.parsed_ocdid,
+                    self.division_output_dir,
+                    self.jurisdiction_output_dir,
+                )
+                logger.info(
+                    "Ancestor stub check complete",
+                    extra={
+                        "ocdid": self.data.ocdid.raw_ocdid,
+                        "ancestor_count": len(ancestor_results),
+                        "created": sum(1 for r in ancestor_results if r["action"] == "created"),
+                    },
+                )
+            except Exception:
+                logger.error(
+                    "Ancestor stub generation failed for %s",
+                    self.data.ocdid.raw_ocdid,
+                    exc_info=True,
+                )
+
             return response
 
         except Exception as e:

--- a/src/init_migration/generate_recursive.py
+++ b/src/init_migration/generate_recursive.py
@@ -1,5 +1,5 @@
 """
-Recursively ensures ancestor Divisions and Jurisdictions exist for a given OCDid.
+Recursively ensure ancestor Divisions and Jurisdictions exist for a given OCDid.
 
 When the pipeline processes a local-government OCDid (e.g. place:seattle under
 state:wa), this module guarantees that each ancestor level (state, county, etc.)
@@ -8,7 +8,6 @@ has at least a placeholder Division and Jurisdiction YAML file on disk.
 Ancestors are stub quality — a separate enrichment pipeline is responsible for
 filling in their full data.  The only contract enforced here is:
   - The `ocdid` field is correct and matches the OCD hierarchy.
-  - Stubs are idempotent: running twice produces no second write.
 """
 from __future__ import annotations
 
@@ -18,54 +17,38 @@ from pathlib import Path
 
 import yaml
 
-from src.models.source import SourceType
-from src.utils.ocdid import ocdid_parser
+from src.models.division import Division, GovernmentIdentifiers
+from src.models.jurisdiction import ClassificationEnum, Jurisdiction
+from src.models.ocdid import OCDidParsed
+from src.models.source import SourceObj, SourceType
 from src.utils.state_lookup import load_state_code_lookup
 
 logger = logging.getLogger(__name__)
 
-# Ancestor segment keys, in priority order used to detect the deepest level.
-_LEVEL_KEYS = ("county", "state", "district", "territory")
-ANCESTOR_START_IND = 3
+# Segment keys that identify a governing-body ancestor level, checked in priority
+# order so that the most-specific level is selected for each ancestor.
+_LEVEL_KEYS: tuple[str, ...] = ("county", "state", "district", "territory")
 
-
-def build_ancestor_ocdids(ocdid: str) -> list[str]:
-    """Return intermediate ancestor OCD IDs, excluding the country root and the leaf.
-
-    For `ocd-division/country:us/state:wa/place:seattle` returns::
-
-        ["ocd-division/country:us/state:wa"]
-
-    For `ocd-division/country:us/state:ca/county:marin/place:sausalito` returns::
-
-        ["ocd-division/country:us/state:ca",
-         "ocd-division/country:us/state:ca/county:marin"]
-
-    Args:
-        ocdid: Any OCD division ID string.
-
-    Returns:
-        Ordered list of ancestor OCD IDs from shallowest to deepest,
-        excluding the country root and the leaf itself.
-    """
-    parts = ocdid.split("/")
-    # parts[0] = "ocd-division"
-    # parts[1] = "country:us"   ← skip (root)
-    # parts[2..N-1]              ← ancestors we want
-    # parts[N]                   ← leaf (excluded)
-    ancestors = []
-    for end in range(ANCESTOR_START_IND, len(parts)):
-        ancestors.append("/".join(parts[:end]))
-    return ancestors
+_OCD_REPO_URL = (
+    "https://raw.githubusercontent.com/opencivicdata/ocd-division-ids"
+    "/master/identifiers/country-us.csv"
+)
+_STUB_SOURCE = SourceObj(
+    field=["ocdid"],
+    source_name="ocdid_recursive_stub",
+    source_url={"ocd_repo": _OCD_REPO_URL},
+    source_type=SourceType.HUMAN,
+    source_description="Placeholder stub — created by recursive ancestor traversal",
+)
 
 
 def stub_exists(ocdid: str, search_dir: Path) -> bool:
-    """Return True if a YAML file in `search_dir` has an `ocdid` matching `ocdid`.
+    """Return True if a YAML file in `search_dir` has a matching `ocdid`.
 
-    Scans only the immediate contents of `search_dir` (non-recursive).
+    Scans only the immediate contents of ``search_dir`` (non-recursive).
 
     Args:
-        ocdid: The OCD ID to search for.
+        ocdid: The OCD ID string to search for.
         search_dir: Directory to scan for YAML files.
 
     Returns:
@@ -100,12 +83,12 @@ def _ancestor_dirs(
     division_output_dir: Path,
     jurisdiction_output_dir: Path,
 ) -> tuple[Path, Path]:
-    """Return ``(div_dir, jur_dir)` for the given ancestor level.
+    """Return `(div_dir, jur_dir)` for the given ancestor level.
 
     Mirrors the `DivGenerator.dump_division` convention of prepending
-    "divisions" / "jurisdictions" to the shared output directory root.
-    State stubs go directly under {state}.
-    County (and other sub-state) stubs go under `{state}/{level}/`.
+    `"divisions"` / `"jurisdictions"` to the shared output-directory root.
+    State/district/territory stubs sit directly under `{state}/`.
+    County stubs sit under `{state}/county/`.
     """
     if level in ("state", "district", "territory"):
         return (
@@ -119,45 +102,49 @@ def _ancestor_dirs(
 
 
 def _write_stub_division(
-    ocdid: str,
+    ancestor: OCDidParsed,
     display_name: str,
     state_fips: str,
     div_dir: Path,
 ) -> Path:
-    """Write a placeholder Division YAML and return the file path."""
-    jur_part = ocdid.replace("ocd-division/", "")
-    now = datetime.now(timezone.utc).isoformat()
-    data = {
-        "ocdid": ocdid,
-        "country": "us",
-        "display_name": display_name,
-        "geometries": [],
-        "also_known_as": [],
-        "jurisdiction_id": f"ocd-jurisdiction/{jur_part}/government",
-        "government_identifiers": {
-            "namelsad": display_name,
-            "statefp": state_fips,
-            "sldust": [],
-            "sldlst": [],
-            "countyfp": [],
-            "county_names": [],
-            "lsad": "",
-            "geoid": state_fips,
-        },
-        "sourcing": [
-            {
-                "field": ["ocdid"],
-                "source_name": "ocdid_recursive_stub",
-                "source_url": {
-                    "ocd_repo": "https://raw.githubusercontent.com/opencivicdata/ocd-division-ids/master/identifiers/country-us.csv"
-                },
-                "source_type": SourceType.HUMAN.value,
-                "source_description": "Placeholder stub — created by recursive ancestor traversal",
-            }
-        ],
-        "accurate_asof": now,
-        "last_updated": now,
-    }
+    """Build a stub Division via the Division model and write it as YAML.
+
+    Args:
+        ancestor: OCDidParsed for this ancestor level.
+        display_name: Human-readable name derived from the ancestor (e.g. "Washington").
+        state_fips: Two-digit FIPS code for the ancestor's state.
+        div_dir: Target directory for the YAML file.
+
+    Returns:
+        Path to the written file.
+    """
+    div_ocdid = ancestor.raw_ocdid
+    jur_part = div_ocdid.replace("ocd-division/", "")
+    now = datetime.now(timezone.utc)
+
+    gov_ids = GovernmentIdentifiers(
+        namelsad=display_name,
+        statefp=state_fips,
+        sldust=[],
+        sldlst=[],
+        countyfp=[],
+        county_names=[],
+        lsad="",
+        geoid=state_fips,
+    )
+
+    division = Division(
+        ocdid=div_ocdid,
+        country=ancestor.country,
+        display_name=display_name,
+        jurisdiction_id=f"ocd-jurisdiction/{jur_part}/government",
+        government_identifiers=gov_ids,
+        sourcing=[_STUB_SOURCE],
+        accurate_asof=now,
+        last_updated=now,
+    )
+
+    data = division.model_dump(mode="json", exclude_none=True)
     div_dir.mkdir(parents=True, exist_ok=True)
     safe_name = display_name.lower().replace(" ", "_")
     path = div_dir / f"{safe_name}_stub.yaml"
@@ -165,33 +152,48 @@ def _write_stub_division(
     return path
 
 
-def _write_stub_jurisdiction(div_ocdid: str, display_name: str, jur_dir: Path) -> Path:
-    """Write a placeholder Jurisdiction YAML and return the file path."""
+def _write_stub_jurisdiction(
+    ancestor: OCDidParsed,
+    display_name: str,
+    jur_dir: Path,
+) -> Path:
+    """Build a stub Jurisdiction via the Jurisdiction model and write it as YAML.
+
+    Args:
+        ancestor: OCDidParsed for this ancestor level.
+        display_name: Human-readable name derived from the ancestor.
+        jur_dir: Target directory for the YAML file.
+
+    Returns:
+        Path to the written file.
+    """
+    div_ocdid = ancestor.raw_ocdid
     div_part = div_ocdid.replace("ocd-division/", "")
     jur_ocdid = f"ocd-jurisdiction/{div_part}/government"
-    now = datetime.now(timezone.utc).isoformat()
-    data = {
-        "ocdid": jur_ocdid,
-        "name": f"{display_name} Government",
-        "url": f"https://opencivicdata.org/division/{div_ocdid}",
-        "classification": "government",
-        "legislative_sessions": {},
-        "feature_flags": [],
-        "metadata": {"urls": []},
-        "sourcing": [
-            {
-                "field": ["ocdid", "name", "classification"],
-                "source_name": "ocdid_recursive_stub",
-                "source_url": {
-                    "ocd_repo": "https://raw.githubusercontent.com/opencivicdata/ocd-division-ids/master/identifiers/country-us.csv"
-                },
-                "source_type": SourceType.HUMAN.value,
-                "source_description": "Placeholder stub — created by recursive ancestor traversal",
-            }
-        ],
-        "accurate_asof": now,
-        "last_updated": now,
-    }
+
+    jur_source = SourceObj(
+        field=["ocdid", "name", "classification"],
+        source_name="ocdid_recursive_stub",
+        source_url={"ocd_repo": _OCD_REPO_URL},
+        source_type=SourceType.HUMAN,
+        source_description="Placeholder stub — created by recursive ancestor traversal",
+    )
+
+    now = datetime.now(timezone.utc)
+    jurisdiction = Jurisdiction(
+        ocdid=jur_ocdid,
+        name=f"{display_name} Government",
+        url=f"https://opencivicdata.org/division/{div_ocdid}",
+        classification=ClassificationEnum.GOVERNMENT,
+        legislative_sessions={},
+        feature_flags=[],
+        metadata={"urls": []},
+        sourcing=[jur_source],
+        accurate_asof=now,
+        last_updated=now,
+    )
+
+    data = jurisdiction.model_dump(mode="json", exclude_none=True)
     jur_dir.mkdir(parents=True, exist_ok=True)
     safe_name = display_name.lower().replace(" ", "_")
     path = jur_dir / f"{safe_name}_stub.yaml"
@@ -200,20 +202,23 @@ def _write_stub_jurisdiction(div_ocdid: str, display_name: str, jur_dir: Path) -
 
 
 def ensure_ancestor_stubs(
-    ocdid: str,
+    parsed_ocdid: OCDidParsed,
     division_output_dir: Path,
     jurisdiction_output_dir: Path,
 ) -> list[dict]:
     """Walk the OCD ID hierarchy and write stubs for any missing ancestor.
 
-    For each ancestor level (state, county, etc.) between the country root and
-    the leaf, checks whether Division and Jurisdiction YAML files already exist.
-    Creates placeholder files for any that are missing.
+    Calls `parsed_ocdid.build_ancestors()` to obtain the list of ancestor
+    OCDidParsed objects, then for each one checks whether Division and
+    Jurisdiction YAML files already exist on disk.
 
     Args:
-        ocdid: Leaf OCDid being processed by the main pipeline.
-        division_output_dir: Path to save division files.
-        jurisdiction_output_dir: Path to save jurisdiction files.
+        parsed_ocdid: OCDidParsed for the leaf OCD ID being processed by the
+            main pipeline (i.e. `self.parsed_ocdid` from GeneratePipeline).
+        division_output_dir: Same `self.division_output_dir` used by
+            GeneratePipeline.
+        jurisdiction_output_dir: Same `self.jurisdiction_output_dir` used by
+            GeneratePipeline.
 
     Returns:
         Ordered list of result dicts, one per ancestor::
@@ -227,24 +232,26 @@ def ensure_ancestor_stubs(
             }
     """
     state_lookup = load_state_code_lookup()
-    ancestors = build_ancestor_ocdids(ocdid)
+    ancestors = parsed_ocdid.build_ancestors()
     results: list[dict] = []
 
-    for ancestor_ocdid in ancestors:
-        parsed = ocdid_parser(ancestor_ocdid)
-
-        level = next((k for k in _LEVEL_KEYS if k in parsed), None)
+    for ancestor in ancestors:
+        # Detect the deepest governing-body level present in this ancestor.
+        level = next(
+            (k for k in _LEVEL_KEYS if getattr(ancestor, k, None)),
+            None,
+        )
         if not level:
-            logger.debug("No recognised level in ancestor %s — skipping", ancestor_ocdid)
+            logger.debug("No recognised level in ancestor %s — skipping", ancestor.raw_ocdid)
             continue
 
-        state_code = (parsed.get("state") or parsed.get("district") or "").lower()
+        state_code = (ancestor.state or getattr(ancestor, "district", None) or "").lower()
         if not state_code:
-            logger.debug("No state code in ancestor %s — skipping", ancestor_ocdid)
+            logger.debug("No state code in ancestor %s — skipping", ancestor.raw_ocdid)
             continue
 
         state_fips, state_full = _resolve_state_info(state_code, state_lookup)
-        level_value: str = parsed[level]
+        level_value: str = getattr(ancestor, level, "") or ""
 
         if level in ("state", "district", "territory"):
             display_name = state_full
@@ -257,15 +264,22 @@ def ensure_ancestor_stubs(
             level, state_code, division_output_dir, jurisdiction_output_dir
         )
 
-        jur_ocdid = f"ocd-jurisdiction/{ancestor_ocdid.replace('ocd-division/', '')}/government"
-        div_exists = stub_exists(ancestor_ocdid, div_dir)
+        jur_ocdid = (
+            f"ocd-jurisdiction/{ancestor.raw_ocdid.replace('ocd-division/', '')}/government"
+        )
+        div_exists = stub_exists(ancestor.raw_ocdid, div_dir)
         jur_exists = stub_exists(jur_ocdid, jur_dir)
 
         if div_exists and jur_exists:
-            logger.debug("Ancestor stubs already exist for %s", ancestor_ocdid)
+            logger.debug("Ancestor stubs already exist for %s", ancestor.raw_ocdid)
             results.append(
-                {"ocdid": ancestor_ocdid, "level": level, "action": "skipped",
-                 "division_path": None, "jurisdiction_path": None}
+                {
+                    "ocdid": ancestor.raw_ocdid,
+                    "level": level,
+                    "action": "skipped",
+                    "division_path": None,
+                    "jurisdiction_path": None,
+                }
             )
             continue
 
@@ -273,22 +287,24 @@ def ensure_ancestor_stubs(
         jur_path: Path | None = None
 
         if not div_exists:
-            div_path = _write_stub_division(ancestor_ocdid, display_name, state_fips, div_dir)
+            div_path = _write_stub_division(ancestor, display_name, state_fips, div_dir)
             logger.info(
-                "Stub Division created for ancestor %s", ancestor_ocdid,
+                "Stub Division created for ancestor %s",
+                ancestor.raw_ocdid,
                 extra={"path": str(div_path)},
             )
 
         if not jur_exists:
-            jur_path = _write_stub_jurisdiction(ancestor_ocdid, display_name, jur_dir)
+            jur_path = _write_stub_jurisdiction(ancestor, display_name, jur_dir)
             logger.info(
-                "Stub Jurisdiction created for ancestor %s", ancestor_ocdid,
+                "Stub Jurisdiction created for ancestor %s",
+                ancestor.raw_ocdid,
                 extra={"path": str(jur_path)},
             )
 
         results.append(
             {
-                "ocdid": ancestor_ocdid,
+                "ocdid": ancestor.raw_ocdid,
                 "level": level,
                 "action": "created",
                 "division_path": str(div_path) if div_path else None,

--- a/src/models/ocdid.py
+++ b/src/models/ocdid.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
 from pydantic import BaseModel, ConfigDict
 from typing import Optional
 from src.utils.ocdid import ocdid_parser
 from src.errors import OCDIdParsingError
+
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class OCDidParsed(BaseModel):
     """
@@ -24,6 +31,58 @@ class OCDidParsed(BaseModel):
             cls(**ocdid_dict)
         except Exception as error:
             raise OCDIdParsingError(error) from error
+
+    def build_ancestors(self) -> list[OCDidParsed]:
+        """Return an OCDidParsed for each ancestor between the country root and this OCD ID.
+
+        Excludes the country root (`ocd-division/country:us`) and the leaf
+        (`self`) from the result.  Returns ancestors ordered from shallowest
+        to deepest.
+
+        Examples::
+
+            OCDidParsed(raw_ocdid="ocd-division/country:us/state:wa/place:seattle",
+                        state="wa", place="seattle").build_ancestors()
+            # → [OCDidParsed(raw_ocdid="ocd-division/country:us/state:wa", state="wa")]
+
+        Returns:
+            Ordered list of OCDidParsed objects, one per ancestor level.
+        """
+        parts = self.raw_ocdid.split("/")
+        # parts[0]="ocd-division", parts[1]="country:us"  ← skip as root
+        # parts[2..N-1] are the ancestors we want; parts[N] is the leaf.
+        known_fields = {"country", "state", "county", "place", "subdivision"}
+        ancestors: list[OCDidParsed] = []
+
+        for end in range(3, len(parts)):
+            ancestor_ocdid = "/".join(parts[:end])
+            try:
+                parsed = ocdid_parser(ancestor_ocdid)
+            except Exception:
+                logger.debug("Could not parse ancestor OCD ID: %s", ancestor_ocdid)
+                continue
+
+            # Collect any non-standard segment keys (e.g. district, anc) as extras
+            # so that extra='allow' stores them as attributes on the model.
+            extras = {
+                k: v
+                for k, v in parsed.items()
+                if k not in known_fields and k != "base"
+            }
+
+            ancestors.append(
+                OCDidParsed(
+                    raw_ocdid=ancestor_ocdid,
+                    country=parsed.get("country", self.country),
+                    state=parsed.get("state"),
+                    county=parsed.get("county"),
+                    place=parsed.get("place"),
+                    subdivision=parsed.get("subdivision"),
+                    **extras,
+                )
+            )
+
+        return ancestors
 
 
 

--- a/tests/src/init_migration/test_generate_recursive.py
+++ b/tests/src/init_migration/test_generate_recursive.py
@@ -2,59 +2,101 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
-from src.init_migration.generate_recursive import (
-    build_ancestor_ocdids,
-    ensure_ancestor_stubs,
-    stub_exists,
-)
+from src.init_migration.generate_recursive import ensure_ancestor_stubs, stub_exists
+from src.models.ocdid import OCDidParsed
 
 
 # ---------------------------------------------------------------------------
-# build_ancestor_ocdids — pure function, no I/O
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_parsed(raw_ocdid: str) -> OCDidParsed:
+    """Build an OCDidParsed from a raw OCD ID string, mirroring how the pipeline
+    constructs it (only known fields are mapped; extras land in model.__pydantic_extra__)."""
+    from src.utils.ocdid import ocdid_parser
+    parsed = ocdid_parser(raw_ocdid)
+    return OCDidParsed(
+        raw_ocdid=raw_ocdid,
+        country=parsed.get("country", "us"),
+        state=parsed.get("state"),
+        county=parsed.get("county"),
+        place=parsed.get("place"),
+        subdivision=parsed.get("subdivision"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# OCDidParsed.build_ancestors — pure, no I/O
 # ---------------------------------------------------------------------------
 
 
-def test_build_ancestor_ocdids_place():
+def test_build_ancestors_place():
     """State is the only ancestor for a state/place OCD ID."""
-    ocdid = "ocd-division/country:us/state:wa/place:seattle"
-    result = build_ancestor_ocdids(ocdid)
-    assert result == ["ocd-division/country:us/state:wa"]
+    parsed = _make_parsed("ocd-division/country:us/state:wa/place:seattle")
+    ancestors = parsed.build_ancestors()
+    assert len(ancestors) == 1
+    assert ancestors[0].raw_ocdid == "ocd-division/country:us/state:wa"
+    assert ancestors[0].state == "wa"
 
 
-def test_build_ancestor_ocdids_county_place():
+def test_build_ancestors_county_place():
     """State then county are returned for a state/county/place OCD ID."""
-    ocdid = "ocd-division/country:us/state:ca/county:marin/place:sausalito"
-    result = build_ancestor_ocdids(ocdid)
-    assert result == [
-        "ocd-division/country:us/state:ca",
-        "ocd-division/country:us/state:ca/county:marin",
-    ]
+    parsed = _make_parsed("ocd-division/country:us/state:ca/county:marin/place:sausalito")
+    ancestors = parsed.build_ancestors()
+    assert len(ancestors) == 2
+    assert ancestors[0].raw_ocdid == "ocd-division/country:us/state:ca"
+    assert ancestors[0].state == "ca"
+    assert ancestors[1].raw_ocdid == "ocd-division/country:us/state:ca/county:marin"
+    assert ancestors[1].county == "marin"
 
 
-def test_build_ancestor_ocdids_council_district():
+def test_build_ancestors_council_district():
     """Place is an ancestor of a council_district OCD ID."""
-    ocdid = "ocd-division/country:us/state:wa/place:seattle/council_district:1"
-    result = build_ancestor_ocdids(ocdid)
-    assert result == [
-        "ocd-division/country:us/state:wa",
-        "ocd-division/country:us/state:wa/place:seattle",
-    ]
+    parsed = _make_parsed("ocd-division/country:us/state:wa/place:seattle/council_district:1")
+    ancestors = parsed.build_ancestors()
+    assert len(ancestors) == 2
+    assert ancestors[0].raw_ocdid == "ocd-division/country:us/state:wa"
+    assert ancestors[1].raw_ocdid == "ocd-division/country:us/state:wa/place:seattle"
 
 
-def test_build_ancestor_ocdids_leaf_excluded():
-    """The leaf node itself is never in the ancestor list."""
-    ocdid = "ocd-division/country:us/state:tx/place:austin"
-    result = build_ancestor_ocdids(ocdid)
-    assert ocdid not in result
+def test_build_ancestors_leaf_excluded():
+    """The leaf OCD ID itself never appears in the ancestor list."""
+    leaf = "ocd-division/country:us/state:tx/place:austin"
+    parsed = _make_parsed(leaf)
+    ancestors = parsed.build_ancestors()
+    assert all(a.raw_ocdid != leaf for a in ancestors)
 
 
-def test_build_ancestor_ocdids_state_only():
-    """A state-level OCD ID has no ancestors to stub."""
-    ocdid = "ocd-division/country:us/state:wa"
-    result = build_ancestor_ocdids(ocdid)
-    assert result == []
+def test_build_ancestors_state_only():
+    """A state-level OCD ID has no ancestors to return."""
+    parsed = _make_parsed("ocd-division/country:us/state:wa")
+    assert parsed.build_ancestors() == []
+
+
+def test_build_ancestors_returns_ocddid_parsed_objects():
+    """Each element in the result is an OCDidParsed instance."""
+    parsed = _make_parsed("ocd-division/country:us/state:ca/county:marin/place:sausalito")
+    ancestors = parsed.build_ancestors()
+    assert all(isinstance(a, OCDidParsed) for a in ancestors)
+
+
+def test_build_ancestors_order():
+    """Ancestors are ordered from shallowest to deepest."""
+    parsed = _make_parsed("ocd-division/country:us/state:ca/county:los_angeles/place:los_angeles")
+    ancestors = parsed.build_ancestors()
+    assert ancestors[0].raw_ocdid == "ocd-division/country:us/state:ca"
+    assert ancestors[1].raw_ocdid == "ocd-division/country:us/state:ca/county:los_angeles"
+    assert len(ancestors) == 2
+
+
+def test_build_ancestors_country_preserved():
+    """country field from the original OCD ID is preserved on each ancestor."""
+    parsed = _make_parsed("ocd-division/country:us/state:wa/place:seattle")
+    ancestors = parsed.build_ancestors()
+    assert all(a.country == "us" for a in ancestors)
 
 
 # ---------------------------------------------------------------------------
@@ -75,14 +117,14 @@ def test_stub_exists_empty_dir(tmp_path: Path):
 def test_stub_exists_match(tmp_path: Path):
     """Returns True when a YAML file contains a matching ocdid field."""
     ocdid = "ocd-division/country:us/state:wa"
-    stub = tmp_path / "washington_state_stub.yaml"
+    stub = tmp_path / "washington_stub.yaml"
     stub.write_text(yaml.dump({"ocdid": ocdid, "display_name": "Washington"}), encoding="utf-8")
     assert stub_exists(ocdid, tmp_path) is True
 
 
 def test_stub_exists_no_match(tmp_path: Path):
     """Returns False when YAML files exist but none matches the given ocdid."""
-    stub = tmp_path / "oregon_state_stub.yaml"
+    stub = tmp_path / "oregon_stub.yaml"
     stub.write_text(
         yaml.dump({"ocdid": "ocd-division/country:us/state:or"}),
         encoding="utf-8",
@@ -98,14 +140,14 @@ def test_stub_exists_ignores_corrupt_yaml(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# ensure_ancestor_stubs — integration (uses real state lookup, tmp_path I/O)
+# ensure_ancestor_stubs — integration (real state lookup + tmp_path I/O)
 # ---------------------------------------------------------------------------
 
 
 def test_ensure_ancestor_stubs_creates_state_stub(tmp_path: Path):
-    """A state-level stub Division and Jurisdiction are created for a place OCD ID."""
-    ocdid = "ocd-division/country:us/state:wa/place:seattle"
-    results = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+    """State-level stub Division and Jurisdiction are created for a place OCD ID."""
+    parsed = _make_parsed("ocd-division/country:us/state:wa/place:seattle")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
 
     assert len(results) == 1
     result = results[0]
@@ -130,8 +172,8 @@ def test_ensure_ancestor_stubs_creates_state_stub(tmp_path: Path):
 
 def test_ensure_ancestor_stubs_creates_county_stub(tmp_path: Path):
     """State and county stubs are both created for a state/county/place OCD ID."""
-    ocdid = "ocd-division/country:us/state:ca/county:marin/place:sausalito"
-    results = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+    parsed = _make_parsed("ocd-division/country:us/state:ca/county:marin/place:sausalito")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
 
     assert len(results) == 2
     levels = {r["level"] for r in results}
@@ -148,55 +190,83 @@ def test_ensure_ancestor_stubs_creates_county_stub(tmp_path: Path):
     assert "county" in div_data["display_name"].lower()
 
 
-def test_ensure_ancestor_stubs_idempotent(tmp_path: Path):
-    """Running twice does not recreate existing stubs."""
-    ocdid = "ocd-division/country:us/state:wa/place:seattle"
+def test_ensure_ancestor_stubs_division_uses_model_fields(tmp_path: Path):
+    """Division YAML produced by the stub contains model-validated fields."""
+    parsed = _make_parsed("ocd-division/country:us/state:tx/place:austin")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
 
-    first = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+    div_data = yaml.safe_load(Path(results[0]["division_path"]).read_text(encoding="utf-8"))
+    # Fields set by Division model
+    assert "ocdid" in div_data
+    assert "country" in div_data
+    assert "display_name" in div_data
+    assert "jurisdiction_id" in div_data
+    assert div_data["jurisdiction_id"].startswith("ocd-jurisdiction/")
+    assert "government_identifiers" in div_data
+    assert "sourcing" in div_data
+    assert "last_updated" in div_data
+
+
+def test_ensure_ancestor_stubs_jurisdiction_uses_model_fields(tmp_path: Path):
+    """Jurisdiction YAML produced by the stub contains model-validated fields."""
+    parsed = _make_parsed("ocd-division/country:us/state:tx/place:austin")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
+
+    jur_data = yaml.safe_load(Path(results[0]["jurisdiction_path"]).read_text(encoding="utf-8"))
+    assert "ocdid" in jur_data
+    assert "name" in jur_data
+    assert "url" in jur_data
+    assert "classification" in jur_data
+    assert "sourcing" in jur_data
+    assert "last_updated" in jur_data
+
+
+def test_ensure_ancestor_stubs_idempotent(tmp_path: Path):
+    """Running twice produces no additional writes."""
+    parsed = _make_parsed("ocd-division/country:us/state:wa/place:seattle")
+
+    first = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
     assert all(r["action"] == "created" for r in first)
 
-    second = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+    second = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
     assert all(r["action"] == "skipped" for r in second)
 
-    # Confirm no duplicate files were written
     state_div_dir = tmp_path / "divisions" / "wa"
     yaml_files = list(state_div_dir.glob("*.yaml"))
     assert len(yaml_files) == 1
 
 
 def test_ensure_ancestor_stubs_no_ancestors_for_state(tmp_path: Path):
-    """A state-level OCD ID has no ancestors to create."""
-    ocdid = "ocd-division/country:us/state:wa"
-    results = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+    """A state-level OCD ID has no ancestors so the result is an empty list."""
+    parsed = _make_parsed("ocd-division/country:us/state:wa")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
     assert results == []
 
 
-def test_ensure_ancestor_stubs_directory_layout(tmp_path: Path):
-    """State stubs land in {output}/divisions/{state}/, not in local/."""
-    ocdid = "ocd-division/country:us/state:tx/place:austin"
-    results = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+def test_ensure_ancestor_stubs_directory_layout_state(tmp_path: Path):
+    """State stubs are written under {output}/divisions/{state}/, not local/."""
+    parsed = _make_parsed("ocd-division/country:us/state:tx/place:austin")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
 
-    assert len(results) == 1
     div_path = Path(results[0]["division_path"])
-    # Should be under divisions/tx/ — NOT under divisions/tx/local/
     assert "tx" in div_path.parts
     assert "local" not in div_path.parts
 
 
-def test_ensure_ancestor_stubs_county_directory_layout(tmp_path: Path):
-    """County stubs land in {output}/divisions/{state}/county/."""
-    ocdid = "ocd-division/country:us/state:ca/county:marin/place:sausalito"
-    results = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+def test_ensure_ancestor_stubs_directory_layout_county(tmp_path: Path):
+    """County stubs are written under {output}/divisions/{state}/county/."""
+    parsed = _make_parsed("ocd-division/country:us/state:ca/county:marin/place:sausalito")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
 
     county_result = next(r for r in results if r["level"] == "county")
     div_path = Path(county_result["division_path"])
     assert "county" in div_path.parts
 
 
-def test_ensure_ancestor_stubs_ocdid_in_div_yaml(tmp_path: Path):
-    """The ocdid field in each stub YAML matches the ancestor OCD ID exactly."""
-    ocdid = "ocd-division/country:us/state:wa/place:tacoma"
-    results = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+def test_ensure_ancestor_stubs_ocdid_field_matches(tmp_path: Path):
+    """The ocdid field in each stub YAML matches the ancestor's raw_ocdid."""
+    parsed = _make_parsed("ocd-division/country:us/state:wa/place:tacoma")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
 
     for result in results:
         data = yaml.safe_load(Path(result["division_path"]).read_text(encoding="utf-8"))
@@ -204,10 +274,19 @@ def test_ensure_ancestor_stubs_ocdid_in_div_yaml(tmp_path: Path):
 
 
 def test_ensure_ancestor_stubs_jur_ocdid_format(tmp_path: Path):
-    """Jurisdiction stub uses the correct ocd-jurisdiction/... prefix."""
-    ocdid = "ocd-division/country:us/state:wa/place:seattle"
-    results = ensure_ancestor_stubs(ocdid, tmp_path, tmp_path)
+    """Jurisdiction stub uses the correct ocd-jurisdiction/…/government format."""
+    parsed = _make_parsed("ocd-division/country:us/state:wa/place:seattle")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
 
     jur_data = yaml.safe_load(Path(results[0]["jurisdiction_path"]).read_text(encoding="utf-8"))
     assert jur_data["ocdid"].startswith("ocd-jurisdiction/")
     assert jur_data["ocdid"].endswith("/government")
+
+
+def test_ensure_ancestor_stubs_country_from_parsed_ocdid(tmp_path: Path):
+    """The country field in the Division stub comes from the OCDidParsed object."""
+    parsed = _make_parsed("ocd-division/country:us/state:wa/place:seattle")
+    results = ensure_ancestor_stubs(parsed, tmp_path, tmp_path)
+
+    div_data = yaml.safe_load(Path(results[0]["division_path"]).read_text(encoding="utf-8"))
+    assert div_data["country"] == parsed.country


### PR DESCRIPTION
… to ocdid

## Change Type

- [ ] YAML data change (divisions / jurisdictions)
- [ x] Code change

## Summary

Refactored to make `generate_recursive` use our pydantic models. Moved `build_ancestors` into `OCDidParsed`.

---

<!-- Complete the section that matches your change type. Delete the other. -->

### YAML Data Change

**What was updated:**
<!-- Which files under `divisions/` or `jurisdictions/`? What was wrong or outdated? -->

---

### Code Change

**Linked Issue:** Closes #

**Validation:**
- [ ] `uv run ruff check .`
