### PR TITLE
fix divisions and jurisdictions paths

### DIFF
--- a/src/init_migration/generate_pipeline.py
+++ b/src/init_migration/generate_pipeline.py
@@ -51,9 +51,11 @@ FUZZY_MATCH_THRESHOLD = 0.85
 DIVISION_FILENAME_PATTERN = "{display_name}_{uuid}.yaml"
 JURISDICTION_FILENAME_PATTERN = "{name}_{uuid}.yaml"
 
-# Output directory constants
-DIVISION_OUTPUT_DIR = "divisions"
-JURISDICTION_OUTPUT_DIR = "jurisdictions"
+# Output directory constants — base dir only. dump_division()/dump_jurisdiction()
+# append the "divisions"/"jurisdictions" segment themselves, so do NOT repeat it
+# here or the path becomes divisions/divisions/<state>/local.
+DIVISION_OUTPUT_DIR = "."
+JURISDICTION_OUTPUT_DIR = "."
 
 
 class NoMatch(BaseModel):


### PR DESCRIPTION
## Change Type

- [ ] YAML data change (divisions / jurisdictions)
- [x] Code change

## Summary

<!-- What changed and why? -->
 fix  duplicated "division" and "jurisdiction" segments in the output path names
---

<!-- Complete the section that matches your change type. Delete the other. -->

### YAML Data Change

**What was updated:**
<!-- Which files under `divisions/` or `jurisdictions/`? What was wrong or outdated? -->

---

### Code Change

**Linked Issue:**  (https://github.com/openstates/jurisdictions/issues/80) 

**Validation:**
- [x] `uv run ruff check .`

desired output screenshot 

<img width="1030" height="145" alt="image" src="https://github.com/user-attachments/assets/cd6fac8d-b6b0-41e7-907e-04be149967e0" />

<img width="1030" height="145" alt="image" src="https://github.com/user-attachments/assets/6e3318b8-c859-4a6a-a686-6525f5dcac0a" />

