### PR TITLE
Add progress bar + tqdm to main.py pipeline (stats to DuckDB)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic>=2.11.9",
     "rapidfuzz>=3.0.0",
     "rich>=14.0.0",
+    "tqdm>=4.68.1",
 ]
 
 [dependency-groups]

--- a/src/init_migration/generate_division.py
+++ b/src/init_migration/generate_division.py
@@ -280,10 +280,10 @@ class DivGenerator:
             raise ValueError("government_identifiers required to save Division")
 
         geoid = self.division.government_identifiers.geoid
-        if not geoid:
-            raise ValueError(
-                "geoid required to generate filename — record should have been quarantined"
-            )
+        # if not geoid:
+        #     raise ValueError(
+        #         "geoid required to generate filename — record should have been quarantined"
+        #     )
 
         try:
             filename = get_division_filename(

--- a/src/init_migration/main.py
+++ b/src/init_migration/main.py
@@ -17,16 +17,18 @@ import asyncio
 import logging
 import sys
 import tempfile
+from datetime import UTC, date, datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+import duckdb
 import httpx
 from rich.console import Console
 from rich.table import Table
 
 from src.utils.state_lookup import load_state_code_lookup
 from src.init_migration.download_manager import DownloadManager
-from src.init_migration.ocdid_matcher import OCDidMatcher, MatchResults
+from src.init_migration.ocdid_matcher import OCDidMatcher, MatchResults, DEFAULT_DB_PATH
 from src.init_migration.generate_pipeline import GeneratePipeline
 from src.init_migration.pipeline_models import DIVISIONS_SHEET_CSV_URL, GeneratorReq
 
@@ -153,6 +155,64 @@ def _cache_validation_csv() -> Path:
     return cache_path
 
 
+GENERATION_TRACKING_PREFIX = "generation_tracking"
+
+
+def generation_tracking_table_name(run_date: date | None = None) -> str:
+    """Build the per-day tracking table name, e.g. generation_tracking_2026_05_23.
+
+    The run date (UTC) is appended so each calendar day gets its own table:
+    re-running on the same day reuses/updates that day's table, while a run on
+    a later day creates a new one.
+    """
+    run_date = run_date or datetime.now(tz=UTC).date()
+    return f"{GENERATION_TRACKING_PREFIX}_{run_date:%Y_%m_%d}"
+
+
+def store_generation_tracking(
+    rows: list[tuple[str, str, str | None, str | None, str | None]],
+    db_path: str = DEFAULT_DB_PATH,
+) -> None:
+    """Persist Phase 3 generation results to a per-day DuckDB tracking table.
+
+    Each row is (original_id, status, error, division_path, jurisdiction_path),
+    derived from a GeneratorResp. The table name carries the run date, so a new
+    day produces a new table. Within the same day the write is idempotent: rows
+    for the same original_id are replaced rather than duplicated. Inserts are
+    batched in a single executemany call.
+    """
+    if not rows:
+        return
+
+    table = generation_tracking_table_name()
+    conn = duckdb.connect(db_path)
+    try:
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                original_id TEXT,
+                status TEXT,
+                error TEXT,
+                division_path TEXT,
+                jurisdiction_path TEXT
+            )
+            """
+        )
+        ids = [r[0] for r in rows]
+        placeholders = ", ".join("?" for _ in ids)
+        conn.execute(
+            f"DELETE FROM {table} WHERE original_id IN ({placeholders})",
+            ids,
+        )
+        conn.executemany(
+            f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+        logger.info(f"Stored {len(rows)} generation tracking record(s) in {table}")
+    finally:
+        conn.close()
+
+
 async def run_pipeline(args: argparse.Namespace) -> MatchResults:
     """Run the full Stage 1 pipeline.
 
@@ -176,6 +236,7 @@ async def run_pipeline(args: argparse.Namespace) -> MatchResults:
 
     # Phase 3: Generate Division and Jurisdiction YAML for every matched record
     phase3_stats = {"success": 0, "skipped": 0, "partial": 0, "failed": 0}
+    tracking_rows: list[tuple[str, str, str | None, str | None, str | None]] = []
     if match_results.matched:
         validation_csv_path = _cache_validation_csv()
         for ingest_resp in match_results.matched:
@@ -187,9 +248,23 @@ async def run_pipeline(args: argparse.Namespace) -> MatchResults:
             try:
                 response = await pipeline.run()
                 phase3_stats[response.status.status.value] += 1
-            except Exception:
+                tracking_rows.append(
+                    (
+                        response.data.ocdid.raw_ocdid,
+                        response.status.status.value,
+                        response.status.error,
+                        response.division_path,
+                        response.jurisdiction_path,
+                    )
+                )
+            except Exception as exc:
                 logger.exception(f"Phase 3 failed for {ingest_resp.ocdid.raw_ocdid}")
                 phase3_stats["failed"] += 1
+                tracking_rows.append(
+                    (ingest_resp.ocdid.raw_ocdid, "failed", str(exc), None, None)
+                )
+        # Phase 4
+        store_generation_tracking(tracking_rows)
 
     # Summary
     print_summary(console, download_stats, match_results, phase3_stats)

--- a/src/init_migration/main.py
+++ b/src/init_migration/main.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import sys
 import tempfile
+import time
 from datetime import UTC, date, datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -25,6 +26,7 @@ import duckdb
 import httpx
 from rich.console import Console
 from rich.table import Table
+from tqdm import tqdm
 
 from src.utils.state_lookup import load_state_code_lookup
 from src.init_migration.download_manager import DownloadManager
@@ -226,20 +228,42 @@ async def run_pipeline(args: argparse.Namespace) -> MatchResults:
     logger.info(f"Starting pipeline for {len(states)} state(s)")
     console.print(f"Processing {len(states)} state(s): {', '.join(states)}")
 
+    pipeline_start = time.perf_counter()
+
     # Phase 1: Download and load
+    phase1_start = time.perf_counter()
     dm = DownloadManager(states=states)
     download_stats = await dm.run_downloads(force=args.force)
+    phase1_elapsed = time.perf_counter() - phase1_start
+    logger.info(
+        "Phase 1 (download) complete",
+        extra={"elapsed_sec": round(phase1_elapsed, 2), "states": states},
+    )
 
     # Phase 2: Match and build
+    phase2_start = time.perf_counter()
     matcher = OCDidMatcher(states=states)
     match_results = matcher.run_matching(show_progress=True)
+    phase2_elapsed = time.perf_counter() - phase2_start
+    logger.info(
+        "Phase 2 (match) complete",
+        extra={
+            "elapsed_sec": round(phase2_elapsed, 2),
+            "matched": len(match_results.matched),
+        },
+    )
 
     # Phase 3: Generate Division and Jurisdiction YAML for every matched record
     phase3_stats = {"success": 0, "skipped": 0, "partial": 0, "failed": 0}
     tracking_rows: list[tuple[str, str, str | None, str | None, str | None]] = []
     if match_results.matched:
         validation_csv_path = _cache_validation_csv()
-        for ingest_resp in match_results.matched:
+        phase3_start = time.perf_counter()
+        for ingest_resp in tqdm(
+            match_results.matched,
+            desc=f"Phase 3 generating YAML ({','.join(states)})",
+            unit="record",
+        ):
             req = GeneratorReq(
                 data=ingest_resp,
                 validation_data_filepath=str(validation_csv_path),
@@ -263,12 +287,30 @@ async def run_pipeline(args: argparse.Namespace) -> MatchResults:
                 tracking_rows.append(
                     (ingest_resp.ocdid.raw_ocdid, "failed", str(exc), None, None)
                 )
+        phase3_elapsed = time.perf_counter() - phase3_start
+        records = len(match_results.matched)
+        logger.info(
+            "Phase 3 (generate) complete",
+            extra={
+                "elapsed_sec": round(phase3_elapsed, 2),
+                "records": records,
+                "sec_per_record": round(phase3_elapsed / records, 3) if records else 0,
+            },
+        )
         # Phase 4
         store_generation_tracking(tracking_rows)
 
+    total_elapsed = time.perf_counter() - pipeline_start
     # Summary
     print_summary(console, download_stats, match_results, phase3_stats)
-    logger.info("Pipeline complete")
+    console.print(
+        f"Total runtime: {total_elapsed:.1f}s "
+        f"for {len(states)} state(s): {', '.join(states)}"
+    )
+    logger.info(
+        "Pipeline complete",
+        extra={"elapsed_sec": round(total_elapsed, 2), "states": states},
+    )
 
     return match_results
 

--- a/uv.lock
+++ b/uv.lock
@@ -325,6 +325,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "rapidfuzz" },
     { name = "rich" },
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -350,6 +351,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "rich", specifier = ">=14.0.0" },
+    { name = "tqdm", specifier = ">=4.68.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -905,6 +907,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/b3/36c8ecf72e8925200671613332db156d84b99b3aee742a41c1938ebb0808/tqdm-4.68.1.tar.gz", hash = "sha256:fc163d96b287bd031e1aa24421ce4411b25559bd0a1be4fe649bdaa4d2c02bf5", size = 171236, upload-time = "2026-06-05T17:23:15.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/aa/218a0eb34de1f753c83e4d0d1c8e7c4cef27f20dcb8342e024f63a80dc86/tqdm-4.68.1-py3-none-any.whl", hash = "sha256:fea4a90e4023f764914569f7802a297277c5ab1a66be5144143e142e1a4031d8", size = 78354, upload-time = "2026-06-05T17:23:13.654Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add a tqdm progress bar to `main.py` so we can gauge how long the pipeline takes to run.
- Remove unnecessary `ValueError` raises for geoids in `generate_division.py`.
- Add the `tqdm` dependency (`pyproject.toml` + `uv.lock`) required by the progress bar.

## Context
Contributes to the runtime-visibility goal of integrating `generate_pipeline.py`
with `main.py` (time tracking to estimate total pipeline runtime).

issue  #72

# tests passed 
<img width="1629" height="451" alt="image" src="https://github.com/user-attachments/assets/6ffca988-00aa-4aa9-8031-2c66172debc4" />
 time tracking

<img width="1611" height="444" alt="image" src="https://github.com/user-attachments/assets/57abf66d-b276-4178-9944-7daef4e06e9d" />

# ruff passed 
<img width="224" height="48" alt="image" src="https://github.com/user-attachments/assets/92cc0476-bf30-420d-b88d-9e4f4f853c2b" />

## Inspecting the pipeline with the DuckDB UI
To browse the pipeline database (including error/status tracking), you need the
DuckDB **CLI** installed locally (it is not a project dependency — the project only
ships the `duckdb` Python library):

```bash
# Install the DuckDB CLI (one-time)
curl https://install.duckdb.org | sh
```

Then open the database with the built-in web UI:

```bash
duckdb -ui data/ocdid_pipeline.duckdb
```

This launches a local server (default http://localhost:4213) with the database
attached. Error/status for each record is tracked in the **`generation_tracking_date`**
table.