### PR TITLE
Correct OCDidParsed to OCDIdParsed to avoid confusion

### DIFF
--- a/ai_tools/planning/stage1-ocdid-pipeline-detailed-plans/2026-02-13-stage1-ocdid-pipeline-design.md
+++ b/ai_tools/planning/stage1-ocdid-pipeline-detailed-plans/2026-02-13-stage1-ocdid-pipeline-design.md
@@ -102,7 +102,7 @@ Matching and UUID generation. Responsibilities:
   - **Local orphan** — local record has no master match (drift detected).
   - **Master orphan** — master record for a given state has no local match.
 - For each matched record:
-  - Parse OCD ID into `OCDidParsed` model
+  - Parse OCD ID into `OCDIdParsed` model
   - Generate deterministic UUID via `uuid5_id.generate_id()`
   - Build `OCDidIngestResp(uuid, ocdid_parsed, raw_record)` where `raw_record`
     contains the **master** record's columns (not local)
@@ -162,7 +162,7 @@ From `src/init_migration/pipeline_models.py` (renamed from `models.py`):
 ```python
 class OCDidIngestResp(BaseModel):
     uuid: str             # changed from UUID → str (holds oid1- deterministic ID)
-    ocdid: OCDidParsed    # changed from str → OCDidParsed
+    ocdid: OCDIdParsed    # changed from str → OCDIdParsed
     raw_record: dict[str, Any]
 ```
 
@@ -171,12 +171,12 @@ class OCDidIngestResp(BaseModel):
   this is the only field to change.
 - The raw OCD ID string remains accessible via `resp.ocdid.raw_ocdid`.
 
-### OCDidParsed — no changes
+### OCDIdParsed — no changes
 
 From `src/models/ocdid.py`:
 
 ```python
-class OCDidParsed(BaseModel):
+class OCDIdParsed(BaseModel):
     country: str = "us"
     state: Optional[str] = None
     county: Optional[str] = None

--- a/ai_tools/planning/stage1-ocdid-pipeline-detailed-plans/2026-02-15-stage1-ocdid-pipeline-implementation.md
+++ b/ai_tools/planning/stage1-ocdid-pipeline-detailed-plans/2026-02-15-stage1-ocdid-pipeline-implementation.md
@@ -111,13 +111,13 @@ Create `tests/src/init_migration/test_pipeline_models.py`:
 """Tests for pipeline_models — specifically the OCDidIngestResp model changes."""
 import pytest
 from src.init_migration.pipeline_models import OCDidIngestResp
-from src.models.ocdid import OCDidParsed
+from src.models.ocdid import OCDIdParsed
 from src.utils.uuid5_id import generate_id
 
 
 def test_ocdid_ingest_resp_accepts_ocdid_parsed():
-    """OCDidIngestResp.ocdid should accept an OCDidParsed instance."""
-    parsed = OCDidParsed(
+    """OCDidIngestResp.ocdid should accept an OCDIdParsed instance."""
+    parsed = OCDIdParsed(
         country="us",
         state="wa",
         place="seattle",
@@ -136,7 +136,7 @@ def test_ocdid_ingest_resp_accepts_ocdid_parsed():
 
 def test_ocdid_ingest_resp_uuid_is_oid1_string():
     """OCDidIngestResp.uuid should accept an oid1- deterministic ID string."""
-    parsed = OCDidParsed(
+    parsed = OCDIdParsed(
         country="us",
         state="wa",
         place="seattle",
@@ -180,14 +180,14 @@ from pydantic import BaseModel, Field
 from typing import Any
 from datetime import datetime, UTC
 from enum import Enum
-from src.models.ocdid import OCDidParsed
+from src.models.ocdid import OCDIdParsed
 
 
 DIVISIONS_SHEET_CSV_URL = "https://docs.google.com/spreadsheets/d/139NETp-iofSoHtl_-IdSSph6xf_ePFVtR8l6KWYadSI/export?format=csv&gid=1481694121"
 
 class OCDidIngestResp(BaseModel):
     uuid: str             # oid1- deterministic ID from uuid5_id.generate_id()
-    ocdid: OCDidParsed
+    ocdid: OCDIdParsed
     raw_record: dict[str, Any]
 
 class GeneratorReq(BaseModel):
@@ -243,7 +243,7 @@ Expected: All tests pass including the new `test_pipeline_models.py`.
 ```bash
 git add src/init_migration/pipeline_models.py src/init_migration/generate_*.py tests/
 git rm --cached src/init_migration/models.py 2>/dev/null || true
-git commit -m "refactor: rename models.py to pipeline_models.py, change OCDidIngestResp.ocdid to OCDidParsed"
+git commit -m "refactor: rename models.py to pipeline_models.py, change OCDidIngestResp.ocdid to OCDIdParsed"
 ```
 
 ---
@@ -934,7 +934,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 from src.init_migration.pipeline_models import OCDidIngestResp
-from src.models.ocdid import OCDidParsed
+from src.models.ocdid import OCDIdParsed
 from src.utils.ocdid import ocdid_parser
 from src.utils.uuid5_id import generate_id
 
@@ -1004,7 +1004,7 @@ class OCDidMatcher:
 
                 # Parse OCD ID
                 parsed_dict = ocdid_parser(ocdid_str)
-                parsed = OCDidParsed(
+                parsed = OCDIdParsed(
                     raw_ocdid=ocdid_str,
                     country=parsed_dict.get("country", "us"),
                     state=parsed_dict.get("state"),

--- a/ai_tools/planning/stage1-ocdid-pipeline-detailed-plans/2026-02-15-stage1-stage2-handoff-fixes.md
+++ b/ai_tools/planning/stage1-ocdid-pipeline-detailed-plans/2026-02-15-stage1-stage2-handoff-fixes.md
@@ -4,7 +4,7 @@
 
 **Goal:** Fix the pipeline plumbing so Stage 1 output (`OCDidIngestResp`) flows cleanly into Stage 2 (`GeneratorReq` → `GeneratePipeline`), resolving type mismatches introduced by the Stage 1 implementation.
 
-**Architecture:** Three categories of fix: (1) return data from `run_pipeline()` instead of discarding it, (2) update Stage 2 code to handle `OCDidParsed` instead of raw strings, (3) add `uuid5_id` field to Division/Jurisdiction models (non-breaking).
+**Architecture:** Three categories of fix: (1) return data from `run_pipeline()` instead of discarding it, (2) update Stage 2 code to handle `OCDIdParsed` instead of raw strings, (3) add `uuid5_id` field to Division/Jurisdiction models (non-breaking).
 
 **Tech Stack:** Pydantic v2, DuckDB, Python 3.12+
 
@@ -14,7 +14,7 @@
 
 Stage 1 implementation changed `OCDidIngestResp` in two ways:
 - `uuid: UUID` → `uuid: str` (now holds oid1- deterministic IDs from `generate_id()`)
-- `ocdid: str` → `ocdid: OCDidParsed` (Pydantic model instead of raw string)
+- `ocdid: str` → `ocdid: OCDIdParsed` (Pydantic model instead of raw string)
 
 Stage 2 code (`generate_pipeline.py`, `generate_division.py`, `generate_jurisdiction.py`) still assumes the old types. Additionally, `main.py` discards Stage 1 results instead of passing them forward.
 
@@ -59,7 +59,7 @@ git commit -m "feat: add uuid5_id field to Division and Jurisdiction models"
 
 ---
 
-## Task 2: Fix `generate_pipeline.py` — handle `OCDidParsed` and `str` uuid
+## Task 2: Fix `generate_pipeline.py` — handle `OCDIdParsed` and `str` uuid
 
 **Files:**
 - Modify: `src/init_migration/generate_pipeline.py`
@@ -75,7 +75,7 @@ Line 121: `ocdid_parser(self.data.ocdid)` → use the already-parsed object:
 self.parsed_ocdid = ocdid_parser(self.data.ocdid)
 
 # After:
-self.parsed_ocdid = self.data.ocdid  # Already OCDidParsed from Stage 1
+self.parsed_ocdid = self.data.ocdid  # Already OCDIdParsed from Stage 1
 ```
 
 Also update the except block (lines 122-124) — parsing can't fail since it's already parsed. Remove the try/except around it.
@@ -121,12 +121,12 @@ Run: `uv run ruff check src/init_migration/generate_pipeline.py`
 
 ```bash
 git add src/init_migration/generate_pipeline.py
-git commit -m "fix: update generate_pipeline.py to handle OCDidParsed and str uuid"
+git commit -m "fix: update generate_pipeline.py to handle OCDIdParsed and str uuid"
 ```
 
 ---
 
-## Task 3: Fix `generate_division.py` — handle `OCDidParsed` and `str` uuid
+## Task 3: Fix `generate_division.py` — handle `OCDIdParsed` and `str` uuid
 
 **Files:**
 - Modify: `src/init_migration/generate_division.py`
@@ -135,7 +135,7 @@ git commit -m "fix: update generate_pipeline.py to handle OCDidParsed and str uu
 
 Line 40: `ocdid_parser(self.data.ocdid)` → use `.raw_ocdid` or the object directly.
 
-Since `DivGenerator` uses `self.parsed_ocdid` as a dict (from `ocdid_parser()` return), and `OCDidParsed` is a Pydantic model (not a dict), we need to pass the raw string:
+Since `DivGenerator` uses `self.parsed_ocdid` as a dict (from `ocdid_parser()` return), and `OCDIdParsed` is a Pydantic model (not a dict), we need to pass the raw string:
 
 ```python
 # Before (line 40):
@@ -165,12 +165,12 @@ uuid5_id=str(uuid),  # oid1- deterministic ID
 
 ```bash
 git add src/init_migration/generate_division.py
-git commit -m "fix: update DivGenerator to handle OCDidParsed and str uuid"
+git commit -m "fix: update DivGenerator to handle OCDIdParsed and str uuid"
 ```
 
 ---
 
-## Task 4: Fix `generate_jurisdiction.py` — handle `OCDidParsed` and `str` uuid
+## Task 4: Fix `generate_jurisdiction.py` — handle `OCDIdParsed` and `str` uuid
 
 **Files:**
 - Modify: `src/init_migration/generate_jurisdiction.py`
@@ -206,9 +206,9 @@ Lines 17-22 and 46-51: Update to use new types:
 
 ```python
 from src.utils.uuid5_id import generate_id
-from src.models.ocdid import OCDidParsed
+from src.models.ocdid import OCDIdParsed
 
-parsed = OCDidParsed(
+parsed = OCDIdParsed(
     raw_ocdid="ocd-division/country:us/state:ca",
     country="us",
     state="ca",

--- a/ai_tools/planning/stage1-ocdid-pipeline-detailed-plans/2026-02-15-stage1-verification-analysis.md
+++ b/ai_tools/planning/stage1-ocdid-pipeline-detailed-plans/2026-02-15-stage1-verification-analysis.md
@@ -28,12 +28,12 @@ to ensure no requirements were lost in translation.
 | 5 | Pull per-state local CSVs | `local_urls()` → `state-{st}-local_gov.csv` | Task 5 | Covered |
 | 6 | For each local record, pull full data from master | Inner join on `id` column | Task 7 SQL join | Covered |
 | 7 | "We will work from the master list" | `raw_record` contains master columns only | Task 7 `m.*` select | Covered |
-| 8 | Parse OCDid in OCDidParsed model | `ocdid_parser()` → `OCDidParsed` | Task 7 | Covered |
+| 8 | Parse OCDid in OCDIdParsed model | `ocdid_parser()` → `OCDIdParsed` | Task 7 | Covered |
 | 9 | Generate a UUID | `uuid5_id.generate_id()` → `oid1-` string | Task 7 | Covered (see note A) |
 | 10 | Store UUID/OCD-ID in DuckDB lookup table | `ocdid_uuid_lookup` table | Task 7 `_store_lookup_table()` | Covered |
 | 11 | "Can be run once, skipped in future runs" | `INSERT ... WHERE NOT EXISTS` idempotency | Task 7 | Covered |
 | 12 | "Backup to a .csv file as well" | `data/ocdid_uuid_lookup.csv` | Task 7 `COPY ... TO` | Covered |
-| 13 | Return `OCDidIngestResp(UUID, OCDidParsed, raw_record)` | Model with `uuid: str`, `ocdid: OCDidParsed`, `raw_record: dict` | Task 2 + Task 7 | Covered |
+| 13 | Return `OCDidIngestResp(UUID, OCDIdParsed, raw_record)` | Model with `uuid: str`, `ocdid: OCDIdParsed`, `raw_record: dict` | Task 2 + Task 7 | Covered |
 
 ### Notes
 

--- a/docs/data_model_relationships.md
+++ b/docs/data_model_relationships.md
@@ -7,7 +7,7 @@
 │                     JURISDICTIONS ECOSYSTEM                          │
 └─────────────────────────────────────────────────────────────────────┘
 
-                    OCDidParsed
+                    OCDIdParsed
                         │
                         │ (represents)
                         │
@@ -33,9 +33,9 @@
 
 ## Detailed Model Relationships
 
-### 1. **OCDidParsed** (Foundation)
+### 1. **OCDIdParsed** (Foundation)
 ```
-OCDidParsed
+OCDIdParsed
 ├── country: str = "us"
 ├── state: Optional[str]
 ├── county: Optional[str]
@@ -196,7 +196,7 @@ Both Division and Jurisdiction share:
 Raw OCD Data
     │
     ▼
-OCDidParsed (parse & validate OCD ID)
+OCDIdParsed (parse & validate OCD ID)
     │
     ├─────────────────────────┬─────────────────────────┐
     │                         │                         │
@@ -279,7 +279,7 @@ This is the PRIMARY KEY for relating the two models.
 
 ```
 When creating a Division, you MUST:
-  ✓ Provide valid ocdid (parsed via OCDidParsed)
+  ✓ Provide valid ocdid (parsed via OCDIdParsed)
   ✓ Provide existing jurisdiction_id
   ✓ Ensure government_identifiers.geoid is populated
   ✓ Ensure sourcing explains data origin

--- a/docs/init_research_pipeline.md
+++ b/docs/init_research_pipeline.md
@@ -18,7 +18,7 @@
         - Map fields in master list to Division model
         - convert the  model to .yaml and store the .yaml file with the UUID
           only as the name
-        - Parse the OCDid in the OCDidParsed model
+        - Parse the OCDid in the OCDIdParsed model
         - Generate a UUID
         - Store OCDid and UUID in DuckDB lookup table for re-runs. 
 
@@ -38,7 +38,7 @@
     -Return:
         OCDidIngestResp() model
             - UUID # id of the stub Division object
-            - OCDidParsed # OCDID from Open Civic Data master list
+            - OCDIdParsed # OCDID from Open Civic Data master list
             - raw record from Open Civic Data master list
 
     - Calls Child Pipeline (GeneratorReq ->)

--- a/src/init_migration/generate_pipeline.py
+++ b/src/init_migration/generate_pipeline.py
@@ -103,7 +103,7 @@ class GeneratePipeline:
         self.division_output_dir = Path(division_output_dir)
         self.jurisdiction_output_dir = Path(jurisdiction_output_dir)
 
-        # OCDid is already parsed as OCDidParsed from Stage 1
+        # OCDid is already parsed as OCDIdParsed from Stage 1
         self.parsed_ocdid = self.data.ocdid
 
         # Initialize generated objects

--- a/src/models/ocdid.py
+++ b/src/models/ocdid.py
@@ -82,7 +82,7 @@ class OCDIdParsed(BaseModel):
     def get_last_segment(cls, ocdid: "OCDIdParsed | OCDIdStr") -> str:
         """
         Extract the last segment from an OCD ID, handling edge cases. This
-        handler accepts both parsed OCDidParsed objects and valid OCD ID
+        handler accepts both parsed OCDIdParsed objects and valid OCD ID
         strings.
         """
         raw_ocdid: str = ocdid.raw_ocdid if isinstance(ocdid, cls) else str(ocdid)

--- a/tests/src/init_migration/test_generate_pipeline_integration.py
+++ b/tests/src/init_migration/test_generate_pipeline_integration.py
@@ -1,0 +1,468 @@
+"""Integration tests for the Generate Pipeline end-to-end with 5 sample records.
+
+Tests the full pipeline flow: CSV loading, fuzzy matching, Division/Jurisdiction
+generation, quarantine tracking, and YAML serialization.
+
+Scope:
+  - Load 5 sample OCDID records with validation data
+  - Run GeneratePipeline for each
+  - Verify output files are created with valid structure
+  - Verify quarantine records for special cases (2 records)
+  - Verify OCDID, GEOID, classification consistency
+
+Sample Records:
+  1. Sausalito (CA city) — should match & generate
+  2. Marin City (CA CDP) — should quarantine (ambiguous match)
+  3. ANC 1A (DC advisory) — should quarantine (no match)
+  4. Seattle Council District 1 (WA) — should match & generate
+  5. Austin Council District 8 (TX) — should match & generate
+"""
+
+import pytest
+import yaml
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID, NAMESPACE_URL, uuid5
+from unittest.mock import MagicMock
+import csv
+
+from src.init_migration.pipeline_models import (
+    GeneratorReq,
+    OCDidIngestResp,
+    GeneratorStatus,
+    Status,
+)
+from src.init_migration.generate_pipeline import GeneratePipeline
+from src.models.ocdid import OCDIdParsed
+from src.models.division import Division
+from src.models.jurisdiction import Jurisdiction
+
+
+# Sample 5 records for integration test
+SAMPLE_OCDIDS = [
+    {
+        "id": "sausalito_ca",
+        "ocdid": "ocd-division/country:us/state:ca/place:sausalito",
+        "expected_geoid": "0670364",
+        "expected_status": Status.SUCCESS,
+        "description": "Sausalito city (CA) — direct place match",
+    },
+    {
+        "id": "marin_city_ca",
+        "ocdid": "ocd-division/country:us/state:ca/county:marin/cdp:marin_city",
+        "expected_geoid": None,  # May not have GEOID
+        "expected_status": Status.PARTIAL,  # Quarantine
+        "description": "Marin City CDP (CA) — ambiguous or no validation match",
+    },
+    {
+        "id": "anc_1a_dc",
+        "ocdid": "ocd-division/country:us/district:dc/anc:1a/council_district:1",
+        "expected_geoid": None,
+        "expected_status": Status.PARTIAL,  # Quarantine
+        "description": "DC ANC 1A District 1 — no validation data available",
+    },
+    {
+        "id": "seattle_council_1_wa",
+        "ocdid": "ocd-division/country:us/state:wa/place:seattle/council_district:1",
+        "expected_geoid": "5363000",
+        "expected_status": Status.SUCCESS,
+        "description": "Seattle Council District 1 (WA) — council district with place match",
+    },
+    {
+        "id": "austin_council_8_tx",
+        "ocdid": "ocd-division/country:us/state:tx/place:austin/council_district:8",
+        "expected_geoid": "4845390165",
+        "expected_status": Status.SUCCESS,
+        "description": "Austin Council District 8 (TX) — council district with place match",
+    },
+]
+
+# Validation CSV data that matches the sample OCD IDs
+# This simulates the Creyton validation dataset
+VALIDATION_CSV_ROWS = [
+    # Sausalito match
+    {
+        "GEOID_Census": "0670364",
+        "STATEFP": "06",
+        "NAMELSAD": "Sausalito city, California",
+        "LSAD": "25",
+        "SLDUST_list": "",
+        "SLDLST_list": "",
+        "COUNTYFP_list": "041",
+        "COUNTY_NAMES": "Marin",
+        "COUSUBFP": "",
+        "PLACEFP": "70364",
+    },
+    # Tacoma match (for fuzzy testing)
+    {
+        "GEOID_Census": "5370000",
+        "STATEFP": "53",
+        "NAMELSAD": "Tacoma city, Washington",
+        "LSAD": "25",
+        "SLDUST_list": "",
+        "SLDLST_list": "",
+        "COUNTYFP_list": "053",
+        "COUNTY_NAMES": "Pierce",
+        "COUSUBFP": "",
+        "PLACEFP": "70000",
+    },
+    # Seattle match
+    {
+        "GEOID_Census": "5363000",
+        "STATEFP": "53",
+        "NAMELSAD": "Seattle city, Washington",
+        "LSAD": "25",
+        "SLDUST_list": "",
+        "SLDLST_list": "",
+        "COUNTYFP_list": "033",
+        "COUNTY_NAMES": "King",
+        "COUSUBFP": "",
+        "PLACEFP": "63000",
+    },
+    # Austin match
+    {
+        "GEOID_Census": "4845390165",
+        "STATEFP": "48",
+        "NAMELSAD": "Austin city, Texas",
+        "LSAD": "25",
+        "SLDUST_list": "",
+        "SLDLST_list": "",
+        "COUNTYFP_list": "453",
+        "COUNTY_NAMES": "Travis",
+        "COUSUBFP": "",
+        "PLACEFP": "01000",
+    },
+    # No Marin City match (intentionally omitted to test quarantine)
+    # No DC data (intentionally omitted to test quarantine)
+]
+
+
+@pytest.fixture
+def validation_csv_file(tmp_path) -> Path:
+    """Create a temporary validation CSV file with sample data."""
+    csv_path = tmp_path / "validation_data.csv"
+
+    # Write header
+    fieldnames = list(VALIDATION_CSV_ROWS[0].keys())
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(VALIDATION_CSV_ROWS)
+
+    return csv_path
+
+
+@pytest.fixture
+def sample_request(validation_csv_file: Path) -> dict:
+    """Create a sample GeneratorReq for testing."""
+    asof_dt = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    return {
+        "validation_filepath": str(validation_csv_file),
+        "asof_datetime": asof_dt,
+    }
+
+
+def _create_ocdid_ingest_resp(ocdid_str: str, asof_dt: datetime) -> OCDidIngestResp:
+    """Helper to create OCDidIngestResp from OCD ID string."""
+    parsed = OCDIdParsed.parse_ocdid(ocdid_str)
+    uuid = uuid5(
+        NAMESPACE_URL,
+        f"{ocdid_str}|{asof_dt.date().isoformat()}",
+    )
+    return OCDidIngestResp(uuid=uuid, ocdid=parsed, raw_record={})
+
+
+def _create_generator_req(
+    ocdid_str: str, validation_filepath: str, asof_dt: datetime
+) -> GeneratorReq:
+    """Helper to create GeneratorReq with proper initialization."""
+    ingest_resp = _create_ocdid_ingest_resp(ocdid_str, asof_dt)
+    return GeneratorReq(
+        data=ingest_resp,
+        validation_data_filepath=validation_filepath,
+        build_base_object=True,
+        jurisdiction_ai_url=False,
+        division_geo_req=False,
+        division_population_req=False,
+        asof_datetime=asof_dt,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_generate_pipeline_5_sample_records(tmp_path, validation_csv_file):
+    """Test pipeline with 5 sample records: verify outputs and quarantine tracking.
+
+    Expected results:
+      1. Sausalito → SUCCESS (match found)
+      2. Marin City → PARTIAL (no/ambiguous match → quarantine)
+      3. ANC 1A → PARTIAL (no validation data → quarantine)
+      4. Seattle CD1 → SUCCESS (match found)
+      5. Austin CD8 → SUCCESS (match found)
+    """
+    asof_dt = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    division_output = tmp_path / "divisions"
+    jurisdiction_output = tmp_path / "jurisdictions"
+    division_output.mkdir()
+    jurisdiction_output.mkdir()
+
+    # Track results
+    results = {
+        "success": [],
+        "partial": [],
+        "failed": [],
+        "responses": [],
+    }
+    quarantine_count = 0
+
+    # Run pipeline for each sample record
+    for sample in SAMPLE_OCDIDS:
+        ocdid = sample["ocdid"]
+        req = _create_generator_req(ocdid, str(validation_csv_file), asof_dt)
+
+        pipeline = GeneratePipeline(
+            req,
+            division_output_dir=division_output,
+            jurisdiction_output_dir=jurisdiction_output,
+        )
+        response = await pipeline.run()
+        results["responses"].append(response)
+
+        status = response.status.status
+        if status == Status.SUCCESS:
+            results["success"].append(sample["id"])
+        elif status == Status.PARTIAL:
+            results["partial"].append(sample["id"])
+            quarantine_count += 1
+        else:
+            results["failed"].append(sample["id"])
+
+    # ========== ASSERTIONS ==========
+
+    # 3 should succeed, 2 should be quarantined (PARTIAL)
+    assert len(results["success"]) == 3, (
+        f"Expected 3 successes, got {len(results['success'])}: "
+        f"{results['success']}"
+    )
+    assert len(results["partial"]) == 2, (
+        f"Expected 2 partial (quarantine), got {len(results['partial'])}: "
+        f"{results['partial']}"
+    )
+    assert len(results["failed"]) == 0, (
+        f"Expected 0 failures, got {len(results['failed'])}: {results['failed']}"
+    )
+
+    # Verify output files created
+    division_files = list(division_output.glob("*.yaml"))
+    assert len(division_files) >= 5, (
+        f"Expected at least 5 division YAML files, got {len(division_files)}"
+    )
+
+    jurisdiction_files = list(jurisdiction_output.glob("*.yaml"))
+    assert len(jurisdiction_files) >= 3, (
+        f"Expected at least 3 jurisdiction YAML files, got {len(jurisdiction_files)}"
+    )
+
+    print(f"\n✓ Generated {len(division_files)} division files")
+    print(f"✓ Generated {len(jurisdiction_files)} jurisdiction files")
+    print(f"✓ {len(results['success'])} records succeeded")
+    print(f"✓ {len(results['partial'])} records quarantined")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_generate_pipeline_successful_record_output(tmp_path, validation_csv_file):
+    """Verify successful record (Sausalito) produces valid Division and Jurisdiction."""
+    asof_dt = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    division_output = tmp_path / "divisions"
+    jurisdiction_output = tmp_path / "jurisdictions"
+    division_output.mkdir()
+    jurisdiction_output.mkdir()
+
+    ocdid = "ocd-division/country:us/state:ca/place:sausalito"
+    req = _create_generator_req(ocdid, str(validation_csv_file), asof_dt)
+
+    pipeline = GeneratePipeline(
+        req,
+        division_output_dir=division_output,
+        jurisdiction_output_dir=jurisdiction_output,
+    )
+    response = await pipeline.run()
+
+    # Verify response structure
+    assert response.status.status == Status.SUCCESS
+    assert response.division_path is not None
+    assert response.jurisdiction_path is not None
+
+    # Verify Division file exists and is valid YAML
+    div_path = Path(response.division_path)
+    assert div_path.exists(), f"Division file not found: {div_path}"
+    with open(div_path) as f:
+        div_data = yaml.safe_load(f)
+    assert div_data is not None
+    assert div_data["ocdid"] == ocdid
+    assert div_data["display_name"] == "Sausalito"
+    assert "accurate_asof" in div_data
+    assert div_data["accurate_asof"] is not None
+
+    # Verify Jurisdiction file exists and is valid YAML
+    jur_path = Path(response.jurisdiction_path)
+    assert jur_path.exists(), f"Jurisdiction file not found: {jur_path}"
+    with open(jur_path) as f:
+        jur_data = yaml.safe_load(f)
+    assert jur_data is not None
+    expected_jur_ocdid = "ocd-jurisdiction/country:us/state:ca/place:sausalito/government"
+    assert jur_data["ocdid"] == expected_jur_ocdid
+    assert jur_data["classification"] == "government"
+    assert "accurate_asof" in jur_data
+    assert jur_data["accurate_asof"] is not None
+
+    print(f"\n✓ Division file: {div_path.name}")
+    print(f"  - ocdid: {div_data['ocdid']}")
+    print(f"  - display_name: {div_data['display_name']}")
+    print(f"  - accurate_asof: {div_data['accurate_asof']}")
+    print(f"\n✓ Jurisdiction file: {jur_path.name}")
+    print(f"  - ocdid: {jur_data['ocdid']}")
+    print(f"  - classification: {jur_data['classification']}")
+    print(f"  - accurate_asof: {jur_data['accurate_asof']}")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_generate_pipeline_quarantine_tracking(tmp_path, validation_csv_file):
+    """Verify quarantine records are properly tracked for no-match cases."""
+    asof_dt = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    division_output = tmp_path / "divisions"
+    jurisdiction_output = tmp_path / "jurisdictions"
+    division_output.mkdir()
+    jurisdiction_output.mkdir()
+
+    # Test the two quarantine cases
+    quarantine_ocdids = [
+        "ocd-division/country:us/state:ca/county:marin/cdp:marin_city",  # Ambiguous
+        "ocd-division/country:us/district:dc/anc:1a/council_district:1",  # No match
+    ]
+
+    for ocdid in quarantine_ocdids:
+        req = _create_generator_req(ocdid, str(validation_csv_file), asof_dt)
+        pipeline = GeneratePipeline(
+            req,
+            division_output_dir=division_output,
+            jurisdiction_output_dir=jurisdiction_output,
+        )
+        response = await pipeline.run()
+
+        # Should be PARTIAL status (quarantine)
+        assert response.status.status == Status.PARTIAL, (
+            f"Expected PARTIAL for {ocdid}, got {response.status.status}"
+        )
+
+        # Division stub should still be created
+        if response.division_path:
+            div_path = Path(response.division_path)
+            assert div_path.exists(), f"Stub division not found for {ocdid}"
+            with open(div_path) as f:
+                div_data = yaml.safe_load(f)
+            assert div_data["ocdid"] == ocdid
+
+        print(f"\n✓ Quarantine case: {ocdid}")
+        print(f"  - Status: {response.status.status}")
+        print(f"  - Error: {response.status.error}")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_generate_pipeline_council_district_logic(tmp_path, validation_csv_file):
+    """Verify council district records correctly map to place-level jurisdictions.
+
+    Council districts like 'seattle/council_district:1' should:
+      - Match against 'seattle' city in validation data
+      - Generate jurisdiction at the place level (not council district level)
+      - Set classification to 'government'
+    """
+    asof_dt = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    division_output = tmp_path / "divisions"
+    jurisdiction_output = tmp_path / "jurisdictions"
+    division_output.mkdir()
+    jurisdiction_output.mkdir()
+
+    ocdid = "ocd-division/country:us/state:wa/place:seattle/council_district:1"
+    req = _create_generator_req(ocdid, str(validation_csv_file), asof_dt)
+
+    pipeline = GeneratePipeline(
+        req,
+        division_output_dir=division_output,
+        jurisdiction_output_dir=jurisdiction_output,
+    )
+    response = await pipeline.run()
+
+    assert response.status.status == Status.SUCCESS
+    assert response.jurisdiction_path is not None
+
+    # Load jurisdiction and verify it's at place level
+    jur_path = Path(response.jurisdiction_path)
+    with open(jur_path) as f:
+        jur_data = yaml.safe_load(f)
+
+    # Jurisdiction should NOT include council_district in ocdid
+    expected_ocdid = "ocd-jurisdiction/country:us/state:wa/place:seattle/government"
+    assert jur_data["ocdid"] == expected_ocdid
+    assert "council_district" not in jur_data["ocdid"]
+
+    print(f"\n✓ Council district logic verified:")
+    print(f"  - Division: {ocdid}")
+    print(f"  - Jurisdiction: {jur_data['ocdid']}")
+    print(f"  - Classification: {jur_data['classification']}")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_generate_pipeline_deduplication(tmp_path, validation_csv_file):
+    """Verify jurisdiction deduplication: multiple council districts → one jurisdiction.
+
+    When processing two council districts from the same place (Seattle),
+    the second should skip jurisdiction creation (already exists).
+    """
+    asof_dt = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    division_output = tmp_path / "divisions"
+    jurisdiction_output = tmp_path / "jurisdictions"
+    division_output.mkdir()
+    jurisdiction_output.mkdir()
+
+    # Create a shared pipeline instance to test deduplication
+    ocdid1 = "ocd-division/country:us/state:wa/place:seattle/council_district:1"
+    ocdid2 = "ocd-division/country:us/state:wa/place:seattle/council_district:2"
+
+    req1 = _create_generator_req(ocdid1, str(validation_csv_file), asof_dt)
+    pipeline = GeneratePipeline(
+        req1,
+        division_output_dir=division_output,
+        jurisdiction_output_dir=jurisdiction_output,
+    )
+
+    response1 = await pipeline.run()
+    assert response1.status.status == Status.SUCCESS
+    assert response1.jurisdiction_path is not None
+    jur_path1 = Path(response1.jurisdiction_path)
+    junction_count_after_1 = len(list(jurisdiction_output.glob("*.yaml")))
+
+    # Now run a second council district from the same city
+    req2 = _create_generator_req(ocdid2, str(validation_csv_file), asof_dt)
+    pipeline2 = GeneratePipeline(
+        req2,
+        division_output_dir=division_output,
+        jurisdiction_output_dir=jurisdiction_output,
+    )
+    response2 = await pipeline2.run()
+    assert response2.status.status == Status.SUCCESS
+    # Note: junction_path might be None if already exists (depending on implementation)
+    junction_count_after_2 = len(list(jurisdiction_output.glob("*.yaml")))
+
+    # Both divisions created, but jurisdictions might be deduplicated
+    division_count = len(list(division_output.glob("*.yaml")))
+    assert division_count >= 2, "Should have at least 2 divisions"
+
+    print(f"\n✓ Deduplication verified:")
+    print(f"  - Divisions: {division_count}")
+    print(f"  - Jurisdictions after CD1: {junction_count_after_1}")
+    print(f"  - Jurisdictions after CD2: {junction_count_after_2}")

--- a/tests/src/init_migration/test_generate_pipeline_integration.py
+++ b/tests/src/init_migration/test_generate_pipeline_integration.py
@@ -22,20 +22,16 @@ import pytest
 import yaml
 from datetime import datetime, timezone
 from pathlib import Path
-from uuid import UUID, NAMESPACE_URL, uuid5
-from unittest.mock import MagicMock
+from uuid import NAMESPACE_URL, uuid5
 import csv
 
 from src.init_migration.pipeline_models import (
     GeneratorReq,
     OCDidIngestResp,
-    GeneratorStatus,
     Status,
 )
 from src.init_migration.generate_pipeline import GeneratePipeline
 from src.models.ocdid import OCDIdParsed
-from src.models.division import Division
-from src.models.jurisdiction import Jurisdiction
 
 
 # Sample 5 records for integration test
@@ -409,7 +405,7 @@ async def test_generate_pipeline_council_district_logic(tmp_path, validation_csv
     assert jur_data["ocdid"] == expected_ocdid
     assert "council_district" not in jur_data["ocdid"]
 
-    print(f"\n✓ Council district logic verified:")
+    print("\n✓ Council district logic verified:")
     print(f"  - Division: {ocdid}")
     print(f"  - Jurisdiction: {jur_data['ocdid']}")
     print(f"  - Classification: {jur_data['classification']}")
@@ -443,7 +439,6 @@ async def test_generate_pipeline_deduplication(tmp_path, validation_csv_file):
     response1 = await pipeline.run()
     assert response1.status.status == Status.SUCCESS
     assert response1.jurisdiction_path is not None
-    jur_path1 = Path(response1.jurisdiction_path)
     junction_count_after_1 = len(list(jurisdiction_output.glob("*.yaml")))
 
     # Now run a second council district from the same city
@@ -462,7 +457,7 @@ async def test_generate_pipeline_deduplication(tmp_path, validation_csv_file):
     division_count = len(list(division_output.glob("*.yaml")))
     assert division_count >= 2, "Should have at least 2 divisions"
 
-    print(f"\n✓ Deduplication verified:")
+    print("\n✓ Deduplication verified:")
     print(f"  - Divisions: {division_count}")
     print(f"  - Jurisdictions after CD1: {junction_count_after_1}")
     print(f"  - Jurisdictions after CD2: {junction_count_after_2}")

--- a/tests/src/init_migration/test_pipeline_models.py
+++ b/tests/src/init_migration/test_pipeline_models.py
@@ -9,7 +9,7 @@ from src.models.ocdid import OCDIdParsed
 
 
 def test_ocdid_ingest_resp_accepts_ocdid_parsed():
-    """OCDidIngestResp.ocdid should accept an OCDidParsed instance."""
+    """OCDidIngestResp.ocdid should accept an OCDIdParsed instance."""
     parsed = OCDIdParsed(
         country="us",
         state="wa",


### PR DESCRIPTION
## Change Type

- [ ] YAML data change (divisions / jurisdictions)
- [x] Code change
- [x] Documentation change

## Summary

Out an abundance of caution, this PR simply changes occurrences of `OCDidParsed` to `OCDIdParsed` which conveniently only appear in documentation and design files as well as one test file. Some ruff errors popped up as a result of changes to the tests. 

**Validation:**
- [x] `uv run ruff check .`
