### PR TITLE
docs: fix FAQ model relationships link

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -104,7 +104,7 @@ They are related, but not interchangeable.
 
 A jurisdiction governs one or more divisions. A division may be governed by multiple jurisdictions (overlapping authorities).
 
-**For a detailed visual overview of these relationships,** see [docs/data_model_relationships.md](../docs/data_model_relationships.md).
+**For a detailed visual overview of these relationships,** see [docs/data_model_relationships.md](docs/data_model_relationships.md).
 
 **See also:** [README.md - Core Concepts](README.md#core-concepts)
 


### PR DESCRIPTION
﻿Summary
- Fixes the FAQ model relationships link so it resolves to `docs/data_model_relationships.md` from the root-level FAQ.
- Keeps the change scoped to documentation only.
- Closes #113.

Validation
- `gh api 'repos/openstates/jurisdictions/git/ref/heads/docs' --silent` returned HTTP 404, confirming the old `docs` branch reference is not available.
- `gh api 'repos/openstates/jurisdictions/contents/docs/data_model_relationships.md?ref=main' --silent` returned HTTP 200, confirming the target document exists on `main`.
- Local link target check confirmed `docs/data_model_relationships.md` exists.
- `git diff --check` passed, with only the local Windows LF/CRLF working-copy warning.
- `uv run --python 3.12 ruff check .` passed.
- `uv run --python 3.12 pytest -m "not integration and not slow"` passed: 149 passed, 9 deselected.

Notes
- Documentation-only change; no data, model, or generated output impact.
- No compatibility impact expected.