### PR TITLE
Fix validation record matching in generate_pipeline (#95)

### DIFF
--- a/docs/validation_record_matching.md
+++ b/docs/validation_record_matching.md
@@ -1,0 +1,195 @@
+# Matching OCDids to Validation Records
+
+How `GeneratePipeline.find_matches()` decides which row of the validation sheet
+describes a given OCDid, why it used to get this wrong, and what you need to know
+about the underlying Census data to change it safely.
+
+## Background: the three vocabularies
+
+Matching sits at the seam between three naming systems. Most of the bugs in this
+area come from treating them as interchangeable.
+
+**1. The OCDid.** A slash-separated path of `type:type_id` pairs, e.g.
+`ocd-division/country:us/state:wa/place:oak_harbor/council_district:3`. Per the
+[OCD spec](https://open-civic-data.readthedocs.io/en/latest/proposals/0002.html),
+`type_id` is always lowercase and may contain underscores and hyphens. It is a
+**slug**, not a name: `oak_harbor`, not `Oak Harbor`.
+
+**2. Census `NAMELSAD`.** The validation sheet's name column. It is the place's
+name *concatenated with its LSAD phrase*: `Oak Harbor city`, `Abbeville CCD`,
+`Juneau city and borough`. The name alone is never stored separately, so every
+consumer has to strip the affix.
+
+**3. LSAD (Legal/Statistical Area Description).** A two-character Census code
+describing what kind of entity the row is, and how its name is decorated. `25` is
+`city` (suffix), `22` is `CCD` (suffix), `28` is `District` (**prefix**). The full
+table lives in `src/data/lsad_map.json`, generated from the Census code list by
+`src/data/lsad_mapper.py`.
+
+## Background: the validation sheet has exactly two layers
+
+This is the single most important fact about the data, and it is not obvious.
+
+The sheet contains **68,308 rows across two Census layers**, distinguished by the
+`layer` column and, equivalently, by which FIPS column is populated:
+
+| layer | rows | `PLACEFP` | `COUSUBFP` | what it is |
+|---|---|---|---|---|
+| `place` | 31,958 | populated | blank | cities, towns, villages, CDPs |
+| `cousub` | 36,349 | blank | populated | county subdivisions (CCDs, townships) |
+
+Two consequences:
+
+- **There are no county rows.** Not one. An OCDid of the form
+  `.../county:king/council_district:2` has nothing it could ever match.
+- **The two layers share names.** `Seattle city` (place) and `Seattle East CCD`
+  (cousub) both exist in Washington. A `place:` OCDid must only ever be matched
+  against `place` rows.
+
+You cannot use the LSAD code to tell the layers apart. LSAD `25` ("city") appears
+on 9,957 `place` rows *and* 2,658 `cousub` rows — New England towns are county
+subdivisions that are also legally cities. Filter on `PLACEFP` instead.
+
+## The algorithm
+
+`find_matches()` returns 0, 1, or 2+ rows, and `run()` treats those three outcomes
+differently: 1 row generates a full Division, 0 or 2+ generate a stub and file the
+record to quarantine for a researcher.
+
+1. Parse the OCDid; take `state` and `place`.
+2. Un-slug the place: `oak_harbor` → `oak harbor`.
+3. Resolve the state's FIPS code and filter the sheet to that state.
+4. Filter to the place layer (`PLACEFP` non-blank).
+5. **Exact match** on the normalized name. If any row matches exactly, those rows
+   are the answer.
+6. Only if nothing matched exactly, **fuzzy match** with `token_sort_ratio` at
+   `FUZZY_MATCH_THRESHOLD` (0.85).
+
+Normalized name means `NAMELSAD` with its LSAD affix removed (by table lookup on
+the row's LSAD code) and lowercased. `Oak Harbor city` → `oak harbor`.
+
+## What was broken
+
+Four defects, which together meant a full-state run produced **zero** successful
+records. In the last run before the fix: 924 records quarantined as "no match",
+175 as "multiple matches", 21 hard failures, 0 successes.
+
+### 1. `token_set_ratio` scored subset names at 1.0
+
+`token_set_ratio` compares the *intersection* of the two token sets and discards
+the tokens they do not share. So a one-word query scores a perfect 100 against any
+longer name containing it:
+
+```
+token_set_ratio("spokane", "spokane valley")       = 100
+token_set_ratio("spokane", "mount spokane ccd")    = 100
+```
+
+Querying `place:spokane` returned **6 matches** — the city, Spokane Valley, and
+four unrelated CCDs — so the record was quarantined as ambiguous instead of
+generating. This is why so few YAML files had real content.
+
+`token_sort_ratio` sorts the tokens and compares the whole strings, which keeps
+multi-word names comparable without collapsing distinct places.
+
+### 2. OCDid slugs were compared verbatim
+
+`place:oak_harbor` was matched against `oak harbor` with the underscore intact.
+It scored 0 and produced no match. Worse, it failed *inconsistently*:
+`des_moines` scored 0.90 and passed. The reason is that `token_set_ratio` sorts
+the leftover tokens, so `des moines` survives the sort in alphabetical order while
+`oak harbor` becomes `harbor oak`. Whether a two-word place matched depended on
+whether its words happened to be alphabetical.
+
+### 3. `place_name.py` corrupted names it did not recognize
+
+`namelsad_to_display_name()` stripped the LSAD with a hardcoded regex listing a
+dozen suffixes. `CCD` was not among them. It also had a fallback that retried the
+regex against `s.title()` and **returned the title-cased string even when the
+retry also failed to match**:
+
+```
+"Abbeville CCD"    -> "Abbeville Ccd"
+"Seattle East CCD" -> "Seattle East Ccd"
+```
+
+Any name with an unlisted LSAD came back reformatted. This corrupted
+`Division.display_name`, and it is what the integration test's
+`assert div_data["display_name"] == "Sausalito"` was catching.
+
+### 4. `created` is a reserved `LogRecord` attribute
+
+```python
+logger.info("Ancestor stub check complete", extra={..., "created": ...})
+# KeyError: "Attempt to overwrite 'created' in LogRecord"
+```
+
+`logging` forbids `extra` keys that collide with `LogRecord`'s own fields, and
+`created` is the record timestamp. The call sat at the end of the success path,
+*after* the YAML had been written, so files landed on disk while the broad
+`except Exception` flipped the record to `FAILED`. **Already fixed upstream** (the
+key was renamed to `generated`); documented here because the symptom — YAML on
+disk but zero successes in the tracking table — is baffling otherwise.
+
+## What changed
+
+| File | Change |
+|---|---|
+| `src/utils/place_name.py` | `namelsad_to_display_name(namelsad, lsad_code=None)` strips the affix by LSAD table lookup, falling back to the regex when the code is absent or unknown. Removed the `.title()` fallback. Added `CCD` to the regex and a `coerce_lsad_code()` helper. |
+| `src/init_migration/generate_pipeline.py` | Un-slug the OCDid place segment; filter candidates to the place layer; exact match before fuzzy; `token_sort_ratio` replaces `token_set_ratio`. |
+| `src/init_migration/generate_division.py` | Passes the row's LSAD code into `namelsad_to_display_name()`, so `display_name` is correct. Reuses `coerce_lsad_code()`. |
+| `tests/integration/test_generate_pipeline_integration.py` | Fixed fixture, `rglob`, new regression tests. |
+
+### Results
+
+Every place row in a state, slugified as an OCDid would be, then matched back:
+
+| state | before | after |
+|---|---|---|
+| WA | 375/639 (58.7%) | 631/639 (**98.7%**) |
+| TX | 858/1862 (46.1%) | 1810/1863 (**97.2%**) |
+| OH | 591/1161 (50.9%) | 1126/1161 (**97.0%**) |
+
+Roughly 97% of names resolve on the exact path; fuzzy handles only the ~1% tail.
+That ordering matters: `token_sort_ratio("alto", "alton")` is 0.89, which clears
+the 0.85 threshold. Because Alto has an exact row, exact-first prevents the false
+positive. **Do not remove the exact-match step and rely on the threshold alone.**
+
+### The residual 2-3% is correct behavior
+
+The names that still return 2+ matches are genuinely ambiguous: Ohio has two
+villages named Bainbridge, Washington has two Clear Lakes. A `place:` OCDid
+carries no county, so nothing in the input can disambiguate them. Quarantining
+them for a researcher is the intended outcome, not a bug.
+
+## Test fixture gotcha
+
+The integration fixture originally wrote `NAMELSAD` as `"Sausalito city, California"`.
+**No real row looks like that** — 0 of 68,308 `NAMELSAD` values end in a state
+name. The fixture only passed because `token_set_ratio` ignored the extra tokens;
+under `token_sort_ratio` it scores 0.51 and fails.
+
+If you change the scorer, check the fixture first. When writing new fixture rows,
+mirror the real shape: `"<Name> <LSAD suffix>"`, a populated `PLACEFP` for places,
+a populated `COUSUBFP` and blank `PLACEFP` for county subdivisions.
+
+## Open question: county OCDids
+
+82% of the records fed to Phase 3 (3,662 of 4,446 in a WA run) are shaped
+`.../county:<name>/council_district:<n>`. `find_matches()` does not parse the
+`county` segment, and even if it did, **the validation sheet contains no county
+rows**. These records will keep producing stubs and quarantine entries until
+either:
+
+- a county layer is added to the validation sheet, or
+- county OCDids are filtered out before Phase 3 and handled by a separate path.
+
+This is a scoping decision for whoever owns the validation sheet, not a code fix.
+The warning was downgraded to `debug` so it no longer floods the log, but the
+records still land in quarantine where a researcher can see them.
+
+## Related
+
+- `docs/ocdid_matching_criteria.md` — the OCDid spec itself.
+- `src/data/lsad_mapper.py` — regenerates `lsad_map.json` from the Census page.
+- Census LSAD code list: <https://www.census.gov/library/reference/code-lists/legal-status-codes.html>

--- a/src/init_migration/generate_division.py
+++ b/src/init_migration/generate_division.py
@@ -14,7 +14,7 @@ from src.utils.ocdid import ocdid_parser
 from src.models.division import Division
 from src.models.source import SourceType
 from src.utils.state_lookup import load_state_code_lookup
-from src.utils.place_name import namelsad_to_display_name
+from src.utils.place_name import coerce_lsad_code, namelsad_to_display_name
 from pathlib import Path
 from datetime import datetime, timezone
 from uuid import UUID
@@ -87,19 +87,14 @@ class DivGenerator:
                     f"Missing required NAMELSAD in validation record: {val_rec}"
                 )
 
+            # Normalise lsad — handle "None" strings and Python list reprs from CSV
+            lsad = coerce_lsad_code(val_rec.get("LSAD", ""))
+
             # council_district override takes precedence over NAMELSAD-derived name
             cd_name = _council_district_display_name(self.parsed_ocdid)
-            display_name = cd_name if cd_name else namelsad_to_display_name(namelsad)
-
-            # Normalise lsad — handle "None" strings and Python list reprs from CSV
-            lsad_raw = val_rec.get("LSAD", "") or ""
-            if lsad_raw in ("None", "null"):
-                lsad = ""
-            elif lsad_raw.startswith("["):
-                inner = lsad_raw.strip("[]").replace("'", "").replace('"', "").strip()
-                lsad = inner.split(",")[0].strip() if inner else ""
-            else:
-                lsad = lsad_raw
+            display_name = (
+                cd_name if cd_name else namelsad_to_display_name(namelsad, lsad)
+            )
 
             raw_ocdid = self.data.ocdid.raw_ocdid
             if self._division_exists(raw_ocdid):

--- a/src/init_migration/generate_pipeline.py
+++ b/src/init_migration/generate_pipeline.py
@@ -44,7 +44,33 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-# Fuzzy matching threshold (0-1 scale, 0.85 = 85% match required)
+
+def _similarity(a: str, b: str) -> float:
+    """Score two normalized place names on a 0-1 scale.
+
+    token_sort_ratio, not token_set_ratio: token_set discards the tokens the two
+    strings do not share, so "spokane" scores 1.0 against "spokane valley" and
+    against every "* CCD" county subdivision. Sorting instead of set-differencing
+    keeps multi-word names comparable without collapsing distinct places.
+    """
+    if HAS_RAPIDFUZZ:
+        return fuzz.token_sort_ratio(a, b) / 100
+    return difflib.SequenceMatcher(
+        None, " ".join(sorted(a.split())), " ".join(sorted(b.split()))
+    ).ratio()
+
+
+def _ocdid_slug_to_name(slug: str) -> str:
+    """Turn an OCDid path segment back into a place name.
+
+    OCDid segments are slugs ("oak_harbor"); validation names are plain text
+    ("oak harbor").
+    """
+    return slug.replace("_", " ").strip().lower()
+
+
+# Fuzzy matching threshold (0-1 scale, 0.85 = 85% match required). Only reached
+# when no exact normalized-name match exists, so it never decides a common case.
 FUZZY_MATCH_THRESHOLD = 0.85
 
 # Filename pattern constants
@@ -159,14 +185,26 @@ class GeneratePipeline:
             Updated Polars DataFrame with normalized place name column
         """
         try:
-            # Add normalized place name column (lowercase, LSAD stripped)
-            df = self.validation_df.with_columns(
-                pl.col("NAMELSAD")
-                .map_elements(
+            # Add normalized place name column (lowercase, LSAD stripped). The LSAD
+            # column drives affix removal by table lookup; fall back to regex-only
+            # stripping when the source CSV omits it.
+            if "LSAD" in self.validation_df.columns:
+                name_expr = pl.struct(["NAMELSAD", "LSAD"]).map_elements(
+                    lambda row: namelsad_to_display_name(
+                        row["NAMELSAD"], row["LSAD"]
+                    ).lower()
+                    if row["NAMELSAD"]
+                    else "",
+                    return_dtype=pl.Utf8,
+                )
+            else:
+                name_expr = pl.col("NAMELSAD").map_elements(
                     lambda x: namelsad_to_display_name(x).lower() if x else "",
                     return_dtype=pl.Utf8,
                 )
-                .alias("normalized_place_name")
+
+            df = self.validation_df.with_columns(
+                name_expr.alias("normalized_place_name")
             )
             logger.info("Normalized validation data with place names")
             return df
@@ -200,11 +238,14 @@ class GeneratePipeline:
                     place = f"anc {anc}"
 
             if not state or not place:
-                logger.warning(f"Missing state or place in OCDid: {ocdid}")
+                # County-level OCDids land here. The validation CSV carries only
+                # Census "place" and "cousub" layers, so there is nothing to match
+                # them against; they are quarantined as stubs by run().
+                logger.debug(f"Missing state or place in OCDid: {ocdid}")
                 return pl.DataFrame()
 
             state_upper = state.upper()
-            place_lower = place.lower()
+            place_lower = _ocdid_slug_to_name(place)
 
             # Look up state FIPS code
             from src.utils.state_lookup import load_state_code_lookup
@@ -234,27 +275,42 @@ class GeneratePipeline:
                 )
                 return pl.DataFrame()
 
-            # Fuzzy match on normalized place names
-            matches = []
-            for row in state_df.iter_rows(named=True):
-                normalized_name = row.get("normalized_place_name", "")
-                if normalized_name:
-                    # Use fuzzy matching (token_set_ratio if rapidfuzz available, else SequenceMatcher)
-                    if HAS_RAPIDFUZZ:
-                        score = (
-                            fuzz.token_set_ratio(place_lower, normalized_name) / 100
-                        )  # Normalize to 0-1
-                    else:
-                        score = difflib.SequenceMatcher(
-                            None, place_lower, normalized_name
-                        ).ratio()
-                    if score >= FUZZY_MATCH_THRESHOLD:
-                        matches.append((row, score))
+            # A `place:` OCDid segment denotes a Census place, so county
+            # subdivisions are not candidates. The LSAD code cannot make this
+            # distinction (code 25 "city" appears on both layers); a populated
+            # PLACEFP can.
+            state_df = self._filter_to_place_layer(state_df)
+            if state_df.is_empty():
+                logger.debug(f"No place-layer records for state: {state_upper}")
+                return pl.DataFrame()
+
+            candidates = [
+                row
+                for row in state_df.iter_rows(named=True)
+                if row.get("normalized_place_name")
+            ]
+
+            # Exact normalized-name match wins outright. ~97% of names resolve here,
+            # which keeps the fuzzy threshold away from near-miss pairs it gets
+            # wrong (token_sort_ratio("alto", "alton") is 0.89).
+            matches = [
+                (row, 1.0)
+                for row in candidates
+                if row["normalized_place_name"] == place_lower
+            ]
 
             if not matches:
-                logger.debug(
-                    f"No fuzzy matches found for place: {place} in state {state}"
-                )
+                matches = [
+                    (row, score)
+                    for row, score in (
+                        (row, _similarity(place_lower, row["normalized_place_name"]))
+                        for row in candidates
+                    )
+                    if score >= FUZZY_MATCH_THRESHOLD
+                ]
+
+            if not matches:
+                logger.debug(f"No matches found for place: {place} in state {state}")
                 return pl.DataFrame()
 
             # Convert matches to DataFrame, sorted by score descending
@@ -269,6 +325,20 @@ class GeneratePipeline:
         except Exception:
             logger.error(f"Error in find_matches for {ocdid}", exc_info=True)
             return pl.DataFrame()
+
+    @staticmethod
+    def _filter_to_place_layer(df: pl.DataFrame) -> pl.DataFrame:
+        """Keep only Census place rows, dropping county subdivisions.
+
+        Place rows carry a PLACEFP; county subdivision rows carry a COUSUBFP and
+        leave PLACEFP blank. A CSV without a PLACEFP column is passed through
+        unfiltered.
+        """
+        if "PLACEFP" not in df.columns:
+            return df
+        return df.filter(
+            pl.col("PLACEFP").cast(pl.Utf8).fill_null("").str.strip_chars() != ""
+        )
 
     def jurisdiction_exists(self, jurisdiction_ocdid: str) -> bool:
         """Check if a Jurisdiction with this ocd_id has already been created.

--- a/src/utils/place_name.py
+++ b/src/utils/place_name.py
@@ -7,15 +7,25 @@ Open Civic Data’s identifiers use the Census “place” concept for
 cities/towns/etc., and the associated CSV stores the human-readable names (what
 we’re deriving above).
 
-Regex removes the LSAD phrase that Census puts into NAMELSAD.
+When the record's two-digit LSAD code is known, the affix to remove is looked up
+in ``src/data/lsad_map.json`` (generated from the Census code list by
+``src/data/lsad_mapper.py``). That is exact: the code says whether the affix is a
+prefix or a suffix and what its text is.
+
+``LSAD_RE`` remains as a fallback for records whose LSAD code is absent or not in
+the map. It only covers the most common suffixes, so prefer passing ``lsad_code``.
 
 Examples removed: "city", "town", "village", "borough", "municipality",
-"city and borough", "city and county", "charter township", "consolidated city", "metropolitan government (balance)", "CDP", "plantation"
+"city and borough", "city and county", "charter township", "consolidated city", "metropolitan government (balance)", "CDP", "CCD", "plantation"
 """
 
 import csv
+import json
 import re
+from functools import lru_cache
 from pathlib import Path
+
+LSAD_MAP_PATH = Path(__file__).resolve().parents[1] / "data" / "lsad_map.json"
 
 LSAD_RE = re.compile(
     r"""
@@ -33,29 +43,85 @@ LSAD_RE = re.compile(
         village|
         town|
         city|
-        CDP
+        CDP|
+        CCD
     )\s*$
     """,
     re.IGNORECASE | re.VERBOSE,
 )
 
 
-def namelsad_to_display_name(namelsad: str) -> str:
+@lru_cache(maxsize=1)
+def load_lsad_map() -> dict[str, dict]:
+    """Load the Census LSAD code table, keyed by two-digit code."""
+    with LSAD_MAP_PATH.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def coerce_lsad_code(raw: object) -> str:
+    """Normalise an LSAD cell into a bare code.
+
+    The validation CSV stores LSAD as a bare code ("25"), the string "None"/"null",
+    or a Python list repr ("['25', '43']") when a record spans several codes. Only
+    the first code of a list is meaningful for naming.
+    """
+    if raw is None:
+        return ""
+    value = str(raw).strip()
+    if value in ("", "None", "null"):
+        return ""
+    if value.startswith("["):
+        inner = value.strip("[]").replace("'", "").replace('"', "").strip()
+        value = inner.split(",")[0].strip() if inner else ""
+    return value
+
+
+def _strip_suffix(name: str, suffix: str) -> str:
+    return re.sub(rf"\s+{re.escape(suffix)}\s*$", "", name, flags=re.IGNORECASE).strip()
+
+
+def _strip_prefix(name: str, prefix: str) -> str:
+    return re.sub(rf"^\s*{re.escape(prefix)}\s+", "", name, flags=re.IGNORECASE).strip()
+
+
+def namelsad_to_display_name(namelsad: str, lsad_code: object = None) -> str:
     """
     Strip the LSAD phrase from a Census NAMELSAD to get the human display name.
+
+    Pass ``lsad_code`` (the record's LSAD column) whenever it is available: the
+    affix is then removed by table lookup rather than by regex guesswork, which
+    is the only way to handle the long tail of codes such as CCD.
+
     Examples:
       "Aberdeen city" -> "Aberdeen"
+      "Abbeville CCD" (lsad_code="22") -> "Abbeville"
       "Nashville-Davidson metropolitan government (balance)" -> "Nashville-Davidson"
       "Juneau city and borough" -> "Juneau"
       "Anchorage municipality" -> "Anchorage"
+
+    A name whose affix cannot be identified is returned unchanged, never
+    reformatted — callers rely on the original casing ("McAllen", "ST. LOUIS").
     """
     s = namelsad.strip()
-    # Remove one trailing LSAD phrase if present
-    s2 = LSAD_RE.sub("", s)
-    # If nothing changed (e.g., odd capitalization), try a case-normalized pass
-    if s2 == s:
-        s2 = LSAD_RE.sub("", s.title())
-    return s2.strip()
+    if not s:
+        return ""
+
+    code = coerce_lsad_code(lsad_code)
+    if code:
+        definition = load_lsad_map().get(code)
+        if definition:
+            suffix = definition.get("lsad_suffix")
+            if suffix:
+                stripped = _strip_suffix(s, suffix)
+                if stripped != s:
+                    return stripped
+            prefix = definition.get("lsad_prefix")
+            if prefix:
+                stripped = _strip_prefix(s, prefix)
+                if stripped != s:
+                    return stripped
+
+    return LSAD_RE.sub("", s).strip()
 
 
 def build_place_names_by_state(country_us_csv: Path):

--- a/tests/integration/test_generate_pipeline_integration.py
+++ b/tests/integration/test_generate_pipeline_integration.py
@@ -74,13 +74,17 @@ SAMPLE_OCDIDS = [
 ]
 
 # Validation CSV data that matches the sample OCD IDs
-# This simulates the Creyton validation dataset
+# This simulates the Creyton validation dataset.
+#
+# NAMELSAD must mirror the real sheet: "<name> <LSAD suffix>", with no trailing
+# state name. Place rows carry a PLACEFP and no COUSUBFP; county subdivision
+# (cousub) rows carry a COUSUBFP and no PLACEFP.
 VALIDATION_CSV_ROWS = [
     # Sausalito match
     {
         "GEOID_Census": "0670364",
         "STATEFP": "06",
-        "NAMELSAD": "Sausalito city, California",
+        "NAMELSAD": "Sausalito city",
         "LSAD": "25",
         "SLDUST_list": "",
         "SLDLST_list": "",
@@ -93,7 +97,7 @@ VALIDATION_CSV_ROWS = [
     {
         "GEOID_Census": "5370000",
         "STATEFP": "53",
-        "NAMELSAD": "Tacoma city, Washington",
+        "NAMELSAD": "Tacoma city",
         "LSAD": "25",
         "SLDUST_list": "",
         "SLDLST_list": "",
@@ -106,7 +110,7 @@ VALIDATION_CSV_ROWS = [
     {
         "GEOID_Census": "5363000",
         "STATEFP": "53",
-        "NAMELSAD": "Seattle city, Washington",
+        "NAMELSAD": "Seattle city",
         "LSAD": "25",
         "SLDUST_list": "",
         "SLDLST_list": "",
@@ -119,7 +123,7 @@ VALIDATION_CSV_ROWS = [
     {
         "GEOID_Census": "4845390165",
         "STATEFP": "48",
-        "NAMELSAD": "Austin city, Texas",
+        "NAMELSAD": "Austin city",
         "LSAD": "25",
         "SLDUST_list": "",
         "SLDLST_list": "",
@@ -127,6 +131,47 @@ VALIDATION_CSV_ROWS = [
         "COUNTY_NAMES": "Travis",
         "COUSUBFP": "",
         "PLACEFP": "01000",
+    },
+    # Decoys. Each of these matched its city at score 1.0 under token_set_ratio,
+    # pushing the city into the "multiple matches" quarantine branch.
+    {
+        # Cousub sharing Seattle's name — must be excluded by the place-layer filter.
+        "GEOID_Census": "5303392524",
+        "STATEFP": "53",
+        "NAMELSAD": "Seattle East CCD",
+        "LSAD": "22",
+        "SLDUST_list": "",
+        "SLDLST_list": "",
+        "COUNTYFP_list": "033",
+        "COUNTY_NAMES": "King",
+        "COUSUBFP": "92524",
+        "PLACEFP": "",
+    },
+    {
+        # Distinct place that merely contains Tacoma's name as a token.
+        "GEOID_Census": "5370010",
+        "STATEFP": "53",
+        "NAMELSAD": "Tacoma Valley city",
+        "LSAD": "25",
+        "SLDUST_list": "",
+        "SLDLST_list": "",
+        "COUNTYFP_list": "053",
+        "COUNTY_NAMES": "Pierce",
+        "COUSUBFP": "",
+        "PLACEFP": "70010",
+    },
+    {
+        # Multi-word place: OCDid slug "oak_harbor" must reach "Oak Harbor".
+        "GEOID_Census": "5350360",
+        "STATEFP": "53",
+        "NAMELSAD": "Oak Harbor city",
+        "LSAD": "25",
+        "SLDUST_list": "",
+        "SLDLST_list": "",
+        "COUNTYFP_list": "029",
+        "COUNTY_NAMES": "Island",
+        "COUSUBFP": "",
+        "PLACEFP": "50360",
     },
     # No Marin City match (intentionally omitted to test quarantine)
     # No DC data (intentionally omitted to test quarantine)
@@ -182,6 +227,54 @@ def _create_generator_req(
         division_population_req=False,
         asof_datetime=asof_dt,
     )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("ocdid", "expected_namelsad"),
+    [
+        # A cousub ("Seattle East CCD") and a longer place ("Tacoma Valley city")
+        # both scored 1.0 against the city under token_set_ratio, because that
+        # scorer drops the tokens the two names do not share.
+        ("ocd-division/country:us/state:wa/place:seattle", "Seattle city"),
+        ("ocd-division/country:us/state:wa/place:tacoma", "Tacoma city"),
+        # Underscored slugs were compared verbatim against the spaced name.
+        ("ocd-division/country:us/state:wa/place:oak_harbor", "Oak Harbor city"),
+        # Trailing segments are ignored; the place drives the match.
+        (
+            "ocd-division/country:us/state:wa/place:seattle/council_district:1",
+            "Seattle city",
+        ),
+    ],
+)
+def test_find_matches_returns_exactly_one_place(
+    validation_csv_file, ocdid, expected_namelsad
+):
+    """Each place OCDid resolves to exactly one validation record."""
+    asof_dt = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    req = _create_generator_req(ocdid, str(validation_csv_file), asof_dt)
+    pipeline = GeneratePipeline(req)
+
+    matches = pipeline.find_matches(ocdid)
+
+    assert len(matches) == 1, (
+        f"Expected 1 match for {ocdid}, got {len(matches)}: "
+        f"{matches['NAMELSAD'].to_list() if len(matches) else []}"
+    )
+    assert matches.row(0, named=True)["NAMELSAD"] == expected_namelsad
+
+
+@pytest.mark.integration
+def test_find_matches_excludes_county_subdivisions(validation_csv_file):
+    """County subdivision rows are never candidates for a `place:` OCDid."""
+    asof_dt = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    ocdid = "ocd-division/country:us/state:wa/place:seattle"
+    req = _create_generator_req(ocdid, str(validation_csv_file), asof_dt)
+    pipeline = GeneratePipeline(req)
+
+    matched_names = pipeline.find_matches(ocdid)["NAMELSAD"].to_list()
+
+    assert "Seattle East CCD" not in matched_names
 
 
 @pytest.mark.integration
@@ -247,13 +340,14 @@ async def test_generate_pipeline_5_sample_records(tmp_path, validation_csv_file)
         f"Expected 0 failures, got {len(results['failed'])}: {results['failed']}"
     )
 
-    # Verify output files created
-    division_files = list(division_output.glob("*.yaml"))
+    # Verify output files created. Output is nested (divisions/<state>/local/…),
+    # so this must recurse.
+    division_files = list(division_output.rglob("*.yaml"))
     assert len(division_files) >= 5, (
         f"Expected at least 5 division YAML files, got {len(division_files)}"
     )
 
-    jurisdiction_files = list(jurisdiction_output.glob("*.yaml"))
+    jurisdiction_files = list(jurisdiction_output.rglob("*.yaml"))
     assert len(jurisdiction_files) >= 3, (
         f"Expected at least 3 jurisdiction YAML files, got {len(jurisdiction_files)}"
     )
@@ -442,7 +536,7 @@ async def test_generate_pipeline_deduplication(tmp_path, validation_csv_file):
     response1 = await pipeline.run()
     assert response1.status.status == Status.SUCCESS
     assert response1.jurisdiction_path is not None
-    junction_count_after_1 = len(list(jurisdiction_output.glob("*.yaml")))
+    junction_count_after_1 = len(list(jurisdiction_output.rglob("*.yaml")))
 
     # Now run a second council district from the same city
     req2 = _create_generator_req(ocdid2, str(validation_csv_file), asof_dt)
@@ -454,10 +548,10 @@ async def test_generate_pipeline_deduplication(tmp_path, validation_csv_file):
     response2 = await pipeline2.run()
     assert response2.status.status == Status.SUCCESS
     # Note: junction_path might be None if already exists (depending on implementation)
-    junction_count_after_2 = len(list(jurisdiction_output.glob("*.yaml")))
+    junction_count_after_2 = len(list(jurisdiction_output.rglob("*.yaml")))
 
     # Both divisions created, but jurisdictions might be deduplicated
-    division_count = len(list(division_output.glob("*.yaml")))
+    division_count = len(list(division_output.rglob("*.yaml")))
     assert division_count >= 2, "Should have at least 2 divisions"
 
     print("\n✓ Deduplication verified:")


### PR DESCRIPTION
## Summary

Fixes the `GeneratePipeline.find_matches()` matching logic so the pipeline
generates YAML for the full set of matched OCDids instead of only a handful.

Relates to #95 (does not close it — see **Known limitations** below).

Before this change, running the main pipeline produced Divisions for only ~3–4
OCDids per state; the rest were quarantined as `partial` with *"No validation
match found"*. The root cause was in the name-matching step, not the data.

## What was wrong

`find_matches()` scored each OCDid against the validation sheet with
`rapidfuzz.token_set_ratio`. That scorer **discards the tokens two strings do not
share**, so:

- `"spokane"` scored **1.0** against `"spokane valley"` and against every
  `"… CCD"` county-subdivision row in the state.
- A city therefore matched *multiple* rows, and `run()` sends any 2+-match record
  to quarantine. The cities that happened to be unique were the only ones that
  generated YAML.

Two smaller bugs compounded it:

- OCDid path segments are **slugs** (`oak_harbor`), but they were compared
  verbatim against the sheet's spaced names (`Oak Harbor`), so multi-word places
  never matched.
- Affix stripping (`"Seattle city"` → `"Seattle"`) was regex-only and did not
  cover the long tail of Census LSAD codes (e.g. `CCD`, or prefix codes like
  `District`).

## What this PR changes

**`src/init_migration/generate_pipeline.py`**
- Replaces `token_set_ratio` with `token_sort_ratio` (new `_similarity` helper):
  sorts tokens instead of set-differencing them, so distinct places stay distinct.
- **Exact normalized-name match wins outright** (score 1.0); the 0.85 fuzzy
  threshold is now only reached when there is no exact match (~3% of names), which
  keeps it away from near-miss pairs it gets wrong (`token_sort_ratio("alto",
  "alton")` = 0.89).
- Adds `_filter_to_place_layer()`: a `place:` OCDid can only match the Census
  *place* layer, so county-subdivision rows are dropped. The filter keys on a
  populated `PLACEFP` — **not** on LSAD, because LSAD `25` ("city") appears on
  both layers.
- Adds `_ocdid_slug_to_name()` to un-slug the place segment before comparison.
- County-level OCDids: the `warning` log is downgraded to `debug` and documented
  as expected (they are quarantined as stubs by `run()`).

**`src/utils/place_name.py`**
- `namelsad_to_display_name()` now takes an optional `lsad_code` and, when
  present, strips the affix by table lookup against `src/data/lsad_map.json`
  (exact: knows prefix vs suffix). Regex remains as a fallback and gains `CCD`.
- Adds `coerce_lsad_code()` to normalise the sheet's messy LSAD cells (`"None"`,
  `"null"`, and Python list reprs like `"['25', '43']"`).
- Names whose affix cannot be identified are returned **unchanged** — original
  casing is preserved (`"McAllen"`, `"ST. LOUIS"`).

**`src/init_migration/generate_division.py`**
- Uses `coerce_lsad_code()` and passes the code into `namelsad_to_display_name()`.

**`docs/validation_record_matching.md`** (new)
- Explains the three naming vocabularies (OCDid slug, Census `NAMELSAD`, LSAD
  code), the two-layer structure of the sheet, and how/why the match algorithm
  works — so the next person can change it safely.

## Tests added and why

The old and new code both pass the *original* fixtures, because those fixtures had
no name collisions — so new tests are the only thing that actually pins the bug.

In `tests/integration/test_generate_pipeline_integration.py`:

1. **Corrected the existing fixtures** to mirror the real sheet: `NAMELSAD` is
   `"Sausalito city"`, not `"Sausalito city, California"` (the real column has no
   trailing state name). The old fixtures were unrealistic and hid the bug.

2. **Added three decoy rows** that reproduce the exact failure from #95:
   - `"Seattle East CCD"` — a **county subdivision** sharing Seattle's name. Under
     the old scorer it matched `place:seattle` at 1.0. The place-layer filter must
     exclude it.
   - `"Tacoma Valley city"` — a **distinct place** that merely contains Tacoma's
     name as a token. `token_set_ratio` scored it 1.0 against `place:tacoma`;
     `token_sort_ratio` does not.
   - `"Oak Harbor city"` — a **multi-word place** whose OCDid slug is `oak_harbor`;
     verifies the un-slugging step.

3. **`test_find_matches_returns_exactly_one_place`** (parametrized) — each place
   OCDid, including one with a trailing `council_district:1` segment, resolves to
   **exactly one** record. This is the assertion that fails on `main` and passes
   here.

4. **`test_find_matches_excludes_county_subdivisions`** — asserts the cousub decoy
   is never among the matches.

5. Changed output-file assertions from `.glob("*.yaml")` to `.rglob("*.yaml")`,
   because output is now written to a nested `divisions/<state>/local/…` layout.

## Known limitations (what is *not* fixed here)

This PR fixes place matching. It deliberately does **not** resolve all of #95,
because the remaining gaps are data limitations, not matching bugs:

- **County-level divisions still cannot match.** OCDids like
  `…/county:king/council_district:2` have **no** corresponding row in the
  validation sheet — the sheet contains only `place` and `cousub` layers, zero
  county rows. These are quarantined as stubs (`display_name: Unknown`, empty
  `government_identifiers`) and reported as **`partial`**, not `failed`. This is
  the bulk of the "many files did not generate" symptom and needs a separate
  data source or decision.
- **Silent under-population.** Arkansas, Maine, and Connecticut have **no**
  `SLDUST_list` values anywhere in the sheet, so their Divisions emit
  `sldust: []` and are still reported **`success`**. Nothing flags this today.
- **Source-sheet quality.** ~13% of `GEOID_variants` cells hold `Loading...` or
  `#ERROR!` (unresolved spreadsheet formulas captured at export). The current code
  does not read that column, so this is latent, but worth knowing.

A follow-up worth doing: a post-generation check that flags `success` rows whose
Divisions carry zero district codes would catch both the county-district and
AR/ME/CT cases before they reach YAML.

## How to run locally

```bash
# 1. Install deps (Python 3.12+)
uv sync

# 2. Run the tests added/changed in this PR
uv run pytest tests/integration/test_generate_pipeline_integration.py -v

# Just the two new matching tests:
uv run pytest tests/integration/test_generate_pipeline_integration.py \
  -k "find_matches" -v

# 3. Run the full pipeline for a state and eyeball the output
uv run python src/init_migration/main.py --state wa

#    Generated YAML lands under divisions/wa/local/ and jurisdictions/wa/local/.
#    Before this PR: a handful of files, most named unknown__<uuid>.yaml.
#    After: every place OCDid produces a named Division (e.g.
#    kennewick_5335275_<uuid>.yaml). County-district OCDids remain unknown__…
#    stubs — that is the known limitation above, not a regression.
```

To confirm the fix end-to-end, compare the Phase 3 summary counts (or the
`generation_tracking_<date>` DuckDB table) before and after: `success` should rise
sharply for place-based OCDids, while county-based ones stay `partial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
