### PR TITLE
Resolves #123: Generalize display name to include wards; dedupe juris…

### DIFF
--- a/src/init_migration/generate_division.py
+++ b/src/init_migration/generate_division.py
@@ -10,6 +10,7 @@ Responsibilities:
 """
 
 from src.init_migration.pipeline_models import GeneratorReq
+from src.init_migration.jurisdiction_seed import derive_jurisdiction_ocdid
 from src.utils.ocdid import ocdid_parser
 from src.models.division import Division
 from src.models.source import SourceType
@@ -20,7 +21,6 @@ from datetime import datetime, timezone
 from uuid import UUID
 import logging
 import yaml
-import re
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -41,24 +41,39 @@ def get_division_filename(display_name: str, geoid: str, uuid: UUID) -> str:
     return f"{safe_display_name}_{geoid}_{uuid}.yaml"
 
 
-def _council_district_display_name(parsed_ocdid: dict) -> str | None:
-    """Return the display name for a council_district division, or None if not applicable.
+def _leaf_segment_display_name(parsed_ocdid: dict[str, str]) -> str | None:
+    """Return the display name for a council_district or ward division, or None if not applicable.
 
     For ``place/council_district`` OCD IDs:   "{Place} Council District {N}"
+    For ``place/ward`` OCD IDs:   "{Place} Ward {N}"
     For ``anc/council_district`` OCD IDs:     "ANC {ANC_ID} District {N}"
+
     """
-    council_district = parsed_ocdid.get("council_district")
-    if not council_district:
+
+    council_district_value = parsed_ocdid.get("council_district")
+    if council_district_value:
+        label = "Council District"
+        value = council_district_value
+
+    ward_value = parsed_ocdid.get("ward")
+    if ward_value:
+        label = "Ward"
+        value = ward_value
+
+    if not (council_district_value or ward_value):
         return None
 
-    anc = parsed_ocdid.get("anc")
-    if anc:
-        return f"ANC {anc.upper()} District {council_district}"
+    # ref: https://en.wikipedia.org/wiki/Advisory_Neighborhood_Commission
+    # ref: https://github.com/opencivicdata/ocd-division-ids/blob/master/identifiers/country-us/state-dc-local_gov.csv
+    anc_value = parsed_ocdid.get("anc")
+    if anc_value:
+        label = "District"
+        return f"ANC {anc_value.upper()} {label} {value}"
 
     place = parsed_ocdid.get("place")
     if place:
         city_name = place.replace("_", " ").title()
-        return f"{city_name} Council District {council_district}"
+        return f"{city_name} {label} {value}"
 
     return None
 
@@ -90,10 +105,10 @@ class DivGenerator:
             # Normalise lsad — handle "None" strings and Python list reprs from CSV
             lsad = coerce_lsad_code(val_rec.get("LSAD", ""))
 
-            # council_district override takes precedence over NAMELSAD-derived name
-            cd_name = _council_district_display_name(self.parsed_ocdid)
+            # leaf segment override takes precedence over NAMELSAD-derived name
+            leaf_name = _leaf_segment_display_name(self.parsed_ocdid)
             display_name = (
-                cd_name if cd_name else namelsad_to_display_name(namelsad, lsad)
+                leaf_name if leaf_name else namelsad_to_display_name(namelsad, lsad)
             )
 
             raw_ocdid = self.data.ocdid.raw_ocdid
@@ -110,7 +125,7 @@ class DivGenerator:
                 display_name=display_name,
                 geometries=[],
                 also_known_as=[],
-                jurisdiction_id=self._derive_jurisdiction_id(raw_ocdid),
+                jurisdiction_id=derive_jurisdiction_ocdid(raw_ocdid),
                 government_identifiers={
                     "namelsad": namelsad,
                     "statefp": statefp,
@@ -168,9 +183,9 @@ class DivGenerator:
             raw_ocdid = self.data.ocdid.raw_ocdid
             parsed = ocdid_parser(raw_ocdid)
 
-            cd_name = _council_district_display_name(parsed)
-            if cd_name:
-                display_name = cd_name
+            leaf_name = _leaf_segment_display_name(parsed)
+            if leaf_name:
+                display_name = leaf_name
             else:
                 place = parsed.get("place", "")
                 display_name = place.replace("_", " ").title() if place else "Unknown"
@@ -200,7 +215,7 @@ class DivGenerator:
                 display_name=display_name,
                 geometries=[],
                 also_known_as=[],
-                jurisdiction_id=self._derive_jurisdiction_id(raw_ocdid),
+                jurisdiction_id=derive_jurisdiction_ocdid(raw_ocdid),
                 government_identifiers={
                     "namelsad": display_name,
                     "statefp": state_fips,
@@ -237,11 +252,6 @@ class DivGenerator:
                 exc_info=True,
             )
             raise
-
-    def _derive_jurisdiction_id(self, division_ocdid: str) -> str:
-        division_part = division_ocdid.replace("ocd-division/", "")
-        division_part = re.sub(r"/council_district:[^/]+", "", division_part)
-        return f"ocd-jurisdiction/{division_part}/government"
 
     def _division_exists(self, ocdid: str) -> bool:
         try:

--- a/src/init_migration/generate_jurisdiction.py
+++ b/src/init_migration/generate_jurisdiction.py
@@ -13,6 +13,7 @@ Name and URL resolution order:
 """
 
 from src.init_migration.pipeline_models import GeneratorReq
+from src.init_migration.jurisdiction_seed import derive_jurisdiction_ocdid
 from src.models.division import Division
 from src.models.jurisdiction import Jurisdiction
 from src.models.source import SourceType
@@ -23,7 +24,6 @@ from datetime import datetime, timezone
 from uuid import UUID
 import logging
 import yaml
-import re
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -122,7 +122,7 @@ class JurGenerator:
             if not division or not division.ocdid:
                 raise ValueError("Division object or ocdid is missing")
 
-            jurisdiction_ocdid = self._derive_jurisdiction_ocdid(
+            jurisdiction_ocdid = derive_jurisdiction_ocdid(
                 division.ocdid, classification
             )
 
@@ -182,14 +182,6 @@ class JurGenerator:
                 exc_info=True,
             )
             raise
-
-    def _derive_jurisdiction_ocdid(
-        self, division_ocdid: str, classification: str = "government"
-    ) -> str:
-        """Derive jurisdiction ocd_id from division ocd_id."""
-        division_part = division_ocdid.replace("ocd-division/", "")
-        division_part = re.sub(r"/council_district:[^/]+", "", division_part)
-        return f"ocd-jurisdiction/{division_part}/{classification}"
 
     def _jurisdiction_exists(self, jurisdiction_ocdid: str) -> bool:
         try:

--- a/src/init_migration/generate_pipeline.py
+++ b/src/init_migration/generate_pipeline.py
@@ -14,13 +14,13 @@ Responsibilities:
 
 import logging
 from pathlib import Path
-import re
 from src.init_migration.pipeline_models import (
     GeneratorReq,
     GeneratorResp,
     GeneratorStatus,
     Status,
 )
+from src.init_migration.jurisdiction_seed import derive_jurisdiction_ocdid
 from src.init_migration.generate_division import DivGenerator
 from src.init_migration.generate_jurisdiction import JurGenerator
 from src.init_migration.generate_recursive import ensure_ancestor_stubs
@@ -442,7 +442,7 @@ class GeneratePipeline:
                 )
                 if seed.has_jurisdiction:
                     classification = seed.classification or "government"
-                    jurisdiction_ocdid = self._derive_jurisdiction_ocdid(
+                    jurisdiction_ocdid = derive_jurisdiction_ocdid(
                         self.division.ocdid, classification
                     )
                     if not self.jurisdiction_exists(jurisdiction_ocdid):
@@ -498,24 +498,6 @@ class GeneratePipeline:
             logger.exception(f"Pipeline failed for {self.data.ocdid.raw_ocdid}")
             response.status = GeneratorStatus(status=Status.FAILED, error=str(e))
             return response
-
-    def _derive_jurisdiction_ocdid(
-        self, division_ocdid: str, classification: str = "government"
-    ) -> str:
-        """Derive jurisdiction ocd_id from division ocd_id.
-
-        Schema: ocd-jurisdiction/<division_without_prefix>/<classification>
-
-        Args:
-            division_ocdid: Division OCD ID
-            classification: Jurisdiction classification (from JurisdictionSeed)
-
-        Returns:
-            Jurisdiction OCD ID
-        """
-        division_part = division_ocdid.replace("ocd-division/", "")
-        division_part = re.sub(r"/council_district:[^/]+", "", division_part)
-        return f"ocd-jurisdiction/{division_part}/{classification}"
 
     def save_quarantine_data(self, output_dir: Path | None = None) -> None:
         """Save quarantine data to CSV files for researcher review.

--- a/src/init_migration/jurisdiction_seed.py
+++ b/src/init_migration/jurisdiction_seed.py
@@ -13,8 +13,8 @@ Decision tree (in priority order):
   6. General government types (place, county, anc, etc.) → government jurisdiction
   7. Unknown → no jurisdiction, flag for manual review
 
-NOTE: Council_district is handled by stripping it from the OCD ID and using the
-parent entity type. A council_district division creates a jurisdiction for its
+NOTE: Council_district and ward are handled by stripping it from the OCD ID and using the
+parent entity type. A leaf division creates a jurisdiction for its
 parent (e.g., a city council district creates a city government jurisdiction).
 
 Assumptions:
@@ -71,6 +71,7 @@ from pydantic import BaseModel
 from src.models.jurisdiction import ClassificationEnum
 from src.utils.ocdid import ocdid_parser
 from src.data.lsad_mapper import get_lsad_map, LSADCode
+import re
 
 
 LSAD_CODES: dict[str, LSADCode] = get_lsad_map()
@@ -159,7 +160,10 @@ GOVERNMENT_TYPES = {
 
 # Division segment keys that indicate a sub-division whose jurisdiction belongs
 # to the PARENT entity (not to itself). Strip these before resolving type.
-NON_PARENT_ENTITY_TYPES = {"council_district"}
+
+# refs: 
+#   ward: https://github.com/search?q=repo%3Aopencivicdata%2Focd-division-ids+ward%3A&type=code&p=3
+NON_PARENT_ENTITY_TYPES = {"council_district", "ward"}
 
 # The generated LSAD map is the source of truth for descriptions and associated
 # entity names. These sets describe which mapped LSADs are non-governing purely
@@ -239,6 +243,15 @@ def _extract_primary_division_type(parsed_ocdid: dict) -> str:
 
     return div_keys[-1] if div_keys else "unknown"
 
+def derive_jurisdiction_ocdid(
+        division_ocdid: str, classification: str = "government"
+    ) -> str:
+        """Derive jurisdiction ocd_id from division ocd_id."""
+        division_part = division_ocdid.replace("ocd-division/", "")
+        # Strip out leaf segments
+        pattern = "|".join(re.escape(t) for t in NON_PARENT_ENTITY_TYPES)
+        division_part = re.sub(rf"/({pattern}):[^/]+", "", division_part)
+        return f"ocd-jurisdiction/{division_part}/{classification}"
 
 def infer_jurisdiction_seed(
     ocdid: str,

--- a/tests/src/init_migration/test_generate_division.py
+++ b/tests/src/init_migration/test_generate_division.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from uuid import NAMESPACE_URL, uuid5
 
 from src.init_migration.pipeline_models import GeneratorReq, OCDidIngestResp
-from src.init_migration.generate_division import DivGenerator
+from src.init_migration.generate_division import DivGenerator, _leaf_segment_display_name
 from src.models.ocdid import OCDIdParsed
 from pathlib import Path
 
@@ -57,3 +57,38 @@ def test_div_generator_initializes(sample_req):
 
     # division should be None before generation
     assert dg.division is None
+
+
+def test_leaf_segment_display_name_returns_council_district():
+    # ocd-division/country:us/state:wa/place:seattle/council_district:1
+    parsed_ocdid = {"place": "seattle", "council_district": "1"}
+
+    assert _leaf_segment_display_name(parsed_ocdid) == "Seattle Council District 1"
+
+
+def test_leaf_segment_display_name_returns_ward():
+    # ocd-division/country:us/state:oh/place:cincinnati/ward:4
+    parsed_ocdid = {"place": "cincinnati", "ward": "4"}
+
+    assert _leaf_segment_display_name(parsed_ocdid) == "Cincinnati Ward 4"
+
+
+def test_anc_display_name_returns_anc_and_district():
+    # ocd-division/country:us/district:dc/anc:1a/council_district:1
+    parsed_ocdid = {"district": "dc", "anc": "1a", "council_district": "1"}
+
+    assert _leaf_segment_display_name(parsed_ocdid) == "ANC 1A District 1"
+
+
+def test_place_display_name_returns_place_and_district():
+    # ocd-division/country:us/state:tx/place:austin/council_district:8
+    parsed_ocdid = {"place": "austin", "council_district": "8"}
+
+    assert _leaf_segment_display_name(parsed_ocdid) == "Austin Council District 8"
+
+
+def test_unmatched_string_returns_none():
+    # ocd-division/country:us/state:wa/place:seattle
+    parsed_ocdid = {"place": "seattle"}
+
+    assert _leaf_segment_display_name(parsed_ocdid) is None

--- a/tests/src/init_migration/test_generate_jurisdiction.py
+++ b/tests/src/init_migration/test_generate_jurisdiction.py
@@ -165,51 +165,8 @@ class TestAILookup:
             jur_generator._ai_lookup(sample_division)
 
 
-# ============================================================================
-# TEST: JURISDICTION OCDID DERIVATION
-# ============================================================================
-
-
-class TestDeriveJurisdictionOCDId:
-    """Tests for _derive_jurisdiction_ocdid method."""
-
-    def test_derive_from_standard_division_ocdid(self, jur_generator):
-        """Should derive jurisdiction OCD ID from division OCD ID."""
-        division_ocdid = "ocd-division/country:us/state:ca/place:seattle"
-        result = jur_generator._derive_jurisdiction_ocdid(
-            division_ocdid, classification="government"
-        )
-
-        assert result.startswith("ocd-jurisdiction/")
-        assert "country:us" in result
-        assert "state:ca" in result
-        assert "place:seattle" in result
-        assert result.endswith("/government")
-
-    def test_derive_with_different_classification(self, jur_generator):
-        """Should use provided classification in OCD ID."""
-        division_ocdid = "ocd-division/country:us/state:ca"
-        result_gov = jur_generator._derive_jurisdiction_ocdid(
-            division_ocdid, classification="government"
-        )
-        result_leg = jur_generator._derive_jurisdiction_ocdid(
-            division_ocdid, classification="legislature"
-        )
-
-        assert result_gov.endswith("/government")
-        assert result_leg.endswith("/legislature")
-
-    def test_derive_removes_council_district(self, jur_generator):
-        """Should remove council_district segments from derived OCD ID."""
-        division_ocdid = (
-            "ocd-division/country:us/state:ca/place:seattle/council_district:1"
-        )
-        result = jur_generator._derive_jurisdiction_ocdid(
-            division_ocdid, classification="government"
-        )
-
-        assert "council_district" not in result
-        assert "place:seattle" in result
+# Jurisdiction OCDID derivation moved to jurisdiction_seed.derive_jurisdiction_ocdid;
+# its tests live in tests/src/init_migration/test_jurisdiction_seed.py
 
 
 # ============================================================================

--- a/tests/src/init_migration/test_jurisdiction_seed.py
+++ b/tests/src/init_migration/test_jurisdiction_seed.py
@@ -1,6 +1,9 @@
 import pytest
 
-from src.init_migration.jurisdiction_seed import infer_jurisdiction_seed
+from src.init_migration.jurisdiction_seed import (
+    derive_jurisdiction_ocdid,
+    infer_jurisdiction_seed,
+)
 from src.models.jurisdiction import ClassificationEnum
 
 
@@ -41,3 +44,68 @@ def test_infer_jurisdiction_seed_keeps_census_area_lsad_statistical() -> None:
 
     assert seed.has_jurisdiction is False
     assert seed.reason == "statistical geography"
+
+
+def test_derive_jurisdiction_ocdid_from_standard_division() -> None:
+    """A division with no non-parent segment maps to itself."""
+    result = derive_jurisdiction_ocdid(
+        "ocd-division/country:us/state:ca/place:seattle",
+        classification="government",
+    )
+
+    assert result == "ocd-jurisdiction/country:us/state:ca/place:seattle/government"
+
+
+def test_derive_jurisdiction_ocdid_uses_given_classification() -> None:
+    division_ocdid = "ocd-division/country:us/state:ca"
+
+    result_gov = derive_jurisdiction_ocdid(division_ocdid, classification="government")
+    result_leg = derive_jurisdiction_ocdid(division_ocdid, classification="legislature")
+
+    assert result_gov.endswith("/government")
+    assert result_leg.endswith("/legislature")
+
+
+def test_derive_jurisdiction_ocdid_defaults_to_government() -> None:
+    """DivGenerator relies on the default when it has no classification."""
+    result = derive_jurisdiction_ocdid("ocd-division/country:us/state:ca/place:seattle")
+
+    assert result.endswith("/government")
+
+
+def test_derive_jurisdiction_ocdid_removes_council_district() -> None:
+    """A council district's jurisdiction belongs to its parent place."""
+    result = derive_jurisdiction_ocdid(
+        "ocd-division/country:us/state:ca/place:seattle/council_district:1",
+        classification="government",
+    )
+
+    assert result == "ocd-jurisdiction/country:us/state:ca/place:seattle/government"
+
+
+def test_derive_jurisdiction_ocdid_removes_ward() -> None:
+    """A ward's jurisdiction belongs to its parent place, same as a council district."""
+    result = derive_jurisdiction_ocdid(
+        "ocd-division/country:us/state:oh/place:cincinnati/ward:1",
+        classification="government",
+    )
+
+    assert result == "ocd-jurisdiction/country:us/state:oh/place:cincinnati/government"
+
+
+def test_derive_jurisdiction_ocdid_dedupes_wards_of_one_place() -> None:
+    """Every ward of a place must resolve to the same jurisdiction ocdid.
+
+    This is what lets _jurisdiction_exists() skip creating a duplicate: 26
+    Cincinnati wards should produce one Cincinnati government, not 26.
+    """
+    derived = {
+        derive_jurisdiction_ocdid(
+            f"ocd-division/country:us/state:oh/place:cincinnati/ward:{n}"
+        )
+        for n in range(1, 27)
+    }
+
+    assert derived == {
+        "ocd-jurisdiction/country:us/state:oh/place:cincinnati/government"
+    }


### PR DESCRIPTION
## Change Type

- [ ] YAML data change (divisions / jurisdictions)
- [x] Code change

## Summary

Division YAMLs for ward: OCDids are named without a ward designation or number — the ward number never enters display_name, so the filename collapses to just the place name and a UUID.

This change resolves that issue by handling the ward segment.

As well, moves derive_jurisdiction_ocdid functionality to jurisdiction_seed.py file -- we are duplicating some code there.

---

### Code Change

**Linked Issue:** Closes #123 

**Validation:**
- [x] .venv/bin/python -m pytest tests/src/init_migration/test_generate_division.py
- [x] .venv/bin/python -m src.init_migration.main --state oh --force
- [x] .venv/bin/python -m pytest tests/src/init_migration/test_jurisdiction_seed.py



