### PR TITLE
[Rework] Phase 4.2 — Add TIGER source snapshot adapter

### DIFF
--- a/ai_tools/catalog.yaml
+++ b/ai_tools/catalog.yaml
@@ -60,3 +60,15 @@ assets:
     owner: maintainers
     path: ai_tools/prompts/create-design-and-implementation-plan.prompt.md
     tags: [planning, docs]
+  - id: tiger-source-snapshot-adapter-design
+    type: planning
+    status: draft
+    owner: rework
+    path: ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-design.instruction.md
+    tags: [planning, rework, census, tiger, source-snapshot]
+  - id: tiger-source-snapshot-adapter-implementation
+    type: planning
+    status: draft
+    owner: rework
+    path: ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-implementation.instruction.md
+    tags: [planning, implementation, rework, census, tiger]

--- a/ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-design.instruction.md
+++ b/ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-design.instruction.md
@@ -14,10 +14,10 @@ task: "Phase 4 — Task 4.2"
 ## Overview
 
 Implement the Phase 4.2 Census TIGER adapter as an offline-first source
-snapshot layer. The adapter fetches attributes from pinned, vintage-specific
-TIGERweb layers, verifies that a response is complete, caches the raw response
-with provenance and a checksum, and parses cached attributes into typed Python
-records plus structured row errors.
+snapshot layer. The adapter verifies each composite-service layer's live
+metadata contract before fetching attributes, verifies that the response is
+complete, caches the raw response with provenance and a checksum, and parses
+cached attributes into typed Python records plus structured row errors.
 
 The adapter is a source boundary. It does not resolve Government Units Survey
 records, construct OCD identifiers, instantiate canonical `Division` or
@@ -40,14 +40,16 @@ Related work:
 1. Support state, county, incorporated-place, county-subdivision, unified
    school-district, secondary school-district, and elementary
    school-district attributes.
-2. Keep the lifecycle explicit: `fetch -> verify -> cache -> parse`.
+2. Keep the lifecycle explicit: `metadata preflight -> fetch -> verify -> cache -> parse`.
 3. Run normal parsing and unit tests entirely from cached JSON fixtures.
 4. Preserve GEOID/FIPS/school codes as strings, including leading zeros.
 5. Retain source URL, service/layer identity, vintage, retrieval timestamp,
    record count, and SHA-256 checksum.
-6. Fail closed when TIGERweb reports an error, returns an empty national layer,
+6. Fail closed when a numeric layer no longer identifies the expected vintage,
+   geography, query capability, or field-width contract.
+7. Fail closed when TIGERweb reports an error, returns an empty national layer,
    omits requested fields, or indicates a transfer-limit truncation.
-7. Return one normalized record or one structured error for every input
+8. Return one normalized record or one structured error for every input
    feature; never silently drop source rows.
 
 ### Constraints
@@ -69,13 +71,21 @@ Related work:
 Pinned TIGERweb layer specification
                  |
                  v
+ Live layer metadata preflight
+ - ID and geography name
+ - parent ACS vintage group
+ - January 1 vintage description
+ - Query capability and record limit
+ - required string fields and widths
+                 |
+                 v
        Existing AsyncDownloader
                  |
                  v
         Raw ArcGIS JSON bytes
                  |
                  v
- Structural verification
+ Structural response verification
  - JSON object
  - no ArcGIS error
  - no transfer-limit truncation
@@ -101,9 +111,9 @@ layout; unit tests use `tmp_path`.
 
 ## Source Contract
 
-The first supported release is the January 1, 2025 vintage. Layer IDs are
-pinned to the `ACS 2025` groups rather than the mutable current-vintage
-MapServer layers:
+The first supported release is the January 1, 2025 vintage. The full-resolution
+TIGERweb services expose vintage groups inside composite MapServers, so their
+child layers are addressed by numeric IDs:
 
 | Geography | Service | Layer |
 | --- | --- | ---: |
@@ -115,14 +125,22 @@ MapServer layers:
 | Secondary school district | `School` | 6 |
 | Elementary school district | `School` | 7 |
 
-Each query requests only the identifiers and descriptive attributes needed by
-later normalization/resolution, orders by `GEOID`, requests no geometry, and
-sets the service-supported 100,000-record ceiling. The verifier rejects
-`exceededTransferLimit=true` so a future source-size change cannot create
-silent truncation.
+Before each source query, the adapter fetches the layer metadata endpoint and
+verifies that the numeric layer still has the expected layer ID and name,
+`ACS 2025` parent group, January 1 vintage description, Query capability,
+100,000-record capacity, required string fields, and exact field widths. This
+prevents a future composite-service reordering from silently relabeling another
+vintage as 2025.
 
-Adding another vintage requires a new explicit layer catalog. Reusing a
-mutable endpoint while relabeling it as an older vintage is not allowed.
+Each data query requests only the identifiers and descriptive attributes needed
+by later normalization/resolution, orders by `GEOID`, requests no geometry, and
+sets the service-supported 100,000-record ceiling. The response verifier rejects
+`exceededTransferLimit=true` so a future source-size change cannot create silent
+truncation.
+
+Adding another vintage requires a new explicit layer catalog and metadata
+contract. Reusing a mutable endpoint while relabeling it as an older vintage is
+not allowed.
 
 ## Module Contract
 
@@ -132,7 +150,7 @@ Primary types:
 
 - `TigerGeography`: supported source geography classes.
 - `TigerLayerSpec`: pinned service/layer/field contract.
-- `TigerAdapter`: fetch, verify, cache, refresh, and parse operations.
+- `TigerAdapter`: metadata preflight, fetch, verify, cache, refresh, and parse operations.
 - `TigerSnapshotMetadata`: provenance/checksum sidecar data.
 - `TigerRecord`: normalized TIGER attribute record.
 - `TigerParseError`: reviewable malformed/duplicate source row.
@@ -179,7 +197,7 @@ manifest and checksum pass validation. A 304 with no valid cache fails closed.
 
 | Risk | Mitigation |
 | --- | --- |
-| TIGERweb mutable current layers drift | Pin vintage-specific group layers. |
+| Composite TIGERweb layer IDs drift | Preflight live ID, parent vintage, description, capabilities, and field widths before querying. |
 | Service silently truncates a response | Reject `exceededTransferLimit=true`. |
 | Numeric conversion destroys leading zeros | Require exact-width strings. |
 | Network-dependent tests become flaky | Parse controlled JSON fixtures only. |
@@ -190,8 +208,11 @@ manifest and checksum pass validation. A 304 with no valid cache fails closed.
 ## Acceptance Criteria
 
 - All seven supported geography classes have pinned layer specifications.
+- Every fetch verifies live layer identity, parent vintage, capabilities, record
+  limit, required fields, and exact field widths before querying records.
 - Query URLs request attributes only and deterministic GEOID ordering.
-- Error, malformed, missing-field, and truncated responses fail verification.
+- Metadata drift, malformed responses, missing fields, and truncated responses
+  fail verification.
 - Snapshot and manifest writes are atomic.
 - Manifest checksum is verified before cache reuse or parsing.
 - Leading zeros survive fetch/cache/parse unchanged.

--- a/ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-design.instruction.md
+++ b/ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-design.instruction.md
@@ -1,0 +1,220 @@
+---
+id: tiger-source-snapshot-adapter-design
+type: planning
+owner: rework
+status: draft
+last_updated: 2026-08-10
+tags: [planning, rework, census, tiger, source-snapshot]
+issue: 135
+task: "Phase 4 — Task 4.2"
+---
+
+# TIGER Source Snapshot Adapter — Design
+
+## Overview
+
+Implement the Phase 4.2 Census TIGER adapter as an offline-first source
+snapshot layer. The adapter fetches attributes from pinned, vintage-specific
+TIGERweb layers, verifies that a response is complete, caches the raw response
+with provenance and a checksum, and parses cached attributes into typed Python
+records plus structured row errors.
+
+The adapter is a source boundary. It does not resolve Government Units Survey
+records, construct OCD identifiers, instantiate canonical `Division` or
+`Jurisdiction` models, generate geometry, or render YAML.
+
+Related work:
+
+- Parent rework: #131
+- Source snapshot phase: #135
+- Downstream normalized government layer: #136
+- Downstream government-to-geography resolver: #137
+- Governing plan: `ai_tools/planning/census-pipeline-rework-plan.md`
+- Governing task instruction:
+  `ai_tools/tasks/census-pipeline-rework.instruction.md`
+
+## Goals and Constraints
+
+### Goals
+
+1. Support state, county, incorporated-place, county-subdivision, unified
+   school-district, secondary school-district, and elementary
+   school-district attributes.
+2. Keep the lifecycle explicit: `fetch -> verify -> cache -> parse`.
+3. Run normal parsing and unit tests entirely from cached JSON fixtures.
+4. Preserve GEOID/FIPS/school codes as strings, including leading zeros.
+5. Retain source URL, service/layer identity, vintage, retrieval timestamp,
+   record count, and SHA-256 checksum.
+6. Fail closed when TIGERweb reports an error, returns an empty national layer,
+   omits requested fields, or indicates a transfer-limit truncation.
+7. Return one normalized record or one structured error for every input
+   feature; never silently drop source rows.
+
+### Constraints
+
+- Reuse the existing `AsyncDownloader` through a small injected fetcher
+  protocol; do not create another HTTP client.
+- Do not add GIS dependencies or require PostGIS.
+- Request attributes only (`returnGeometry=false`).
+- Do not store polygon/GeoJSON blobs in repository fixtures or snapshots.
+- Do not modify `src/models/` without separate maintainer approval.
+- Do not modify `tests/sample_output/`.
+- Do not modify `tests/integration/` in this task.
+- Do not construct OCDIDs or feature-specific GeoJSON URLs here; those belong
+  to #137.
+
+## Architecture and Data Flow
+
+```text
+Pinned TIGERweb layer specification
+                 |
+                 v
+       Existing AsyncDownloader
+                 |
+                 v
+        Raw ArcGIS JSON bytes
+                 |
+                 v
+ Structural verification
+ - JSON object
+ - no ArcGIS error
+ - no transfer-limit truncation
+ - features[] present
+ - requested attributes present
+                 |
+                 v
+ Atomic snapshot + manifest
+ data/raw/census/tiger/<vintage>/<type>.json
+ data/raw/census/tiger/<vintage>/<type>.manifest.json
+                 |
+                 v
+ Offline semantic parse
+ - exact string code widths
+ - GEOID/component parity
+ - duplicate GEOID detection
+ - normalized TigerRecord
+ - structured TigerParseError
+```
+
+The caller chooses the cache root. The path above is the intended production
+layout; unit tests use `tmp_path`.
+
+## Source Contract
+
+The first supported release is the January 1, 2025 vintage. Layer IDs are
+pinned to the `ACS 2025` groups rather than the mutable current-vintage
+MapServer layers:
+
+| Geography | Service | Layer |
+| --- | --- | ---: |
+| State | `State_County` | 18 |
+| County | `State_County` | 19 |
+| County subdivision | `Places_CouSub_ConCity_SubMCD` | 8 |
+| Incorporated place | `Places_CouSub_ConCity_SubMCD` | 11 |
+| Unified school district | `School` | 5 |
+| Secondary school district | `School` | 6 |
+| Elementary school district | `School` | 7 |
+
+Each query requests only the identifiers and descriptive attributes needed by
+later normalization/resolution, orders by `GEOID`, requests no geometry, and
+sets the service-supported 100,000-record ceiling. The verifier rejects
+`exceededTransferLimit=true` so a future source-size change cannot create
+silent truncation.
+
+Adding another vintage requires a new explicit layer catalog. Reusing a
+mutable endpoint while relabeling it as an older vintage is not allowed.
+
+## Module Contract
+
+New module: `src/init_migration/tiger_adapter.py`
+
+Primary types:
+
+- `TigerGeography`: supported source geography classes.
+- `TigerLayerSpec`: pinned service/layer/field contract.
+- `TigerAdapter`: fetch, verify, cache, refresh, and parse operations.
+- `TigerSnapshotMetadata`: provenance/checksum sidecar data.
+- `TigerRecord`: normalized TIGER attribute record.
+- `TigerParseError`: reviewable malformed/duplicate source row.
+- `TigerParseResult`: records and errors with an input-count invariant.
+
+The adapter accepts any object implementing the existing downloader's
+`fetch_bytes(url, force=False)` interface. This keeps tests offline and avoids
+coupling source semantics into the HTTP client.
+
+## Cache and Integrity Contract
+
+For each geography class, cache:
+
+1. The raw ArcGIS JSON response exactly as fetched.
+2. A deterministic JSON manifest containing:
+   - manifest schema version;
+   - dataset name;
+   - geography class;
+   - vintage;
+   - service name;
+   - layer ID and name;
+   - exact source query URL;
+   - UTC retrieval timestamp;
+   - SHA-256 of the raw snapshot;
+   - source feature count;
+   - snapshot filename.
+
+Writes are atomic. A 304 response reuses an existing snapshot only after the
+manifest and checksum pass validation. A 304 with no valid cache fails closed.
+
+## Semantic Parse Rules
+
+- `GEOID`, `STATE`, `COUNTY`, `PLACE`, `COUSUB`, `SDUNI`, `SDSEC`, and
+  `SDELM` remain strings and must satisfy exact source widths.
+- `GEOID` must equal its component codes for the geography class.
+- Source names are preserved; no name normalization occurs in this phase.
+- School-district type may be blank in authoritative TIGER records and is preserved as `None`; invalid nonblank codes remain errors.
+- Duplicate GEOIDs are emitted as errors rather than overwritten.
+- A malformed feature produces `TigerParseError` with feature index, available
+  GEOID, message, and source attributes.
+- `len(records) + len(errors)` must equal the number of input features.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| TIGERweb mutable current layers drift | Pin vintage-specific group layers. |
+| Service silently truncates a response | Reject `exceededTransferLimit=true`. |
+| Numeric conversion destroys leading zeros | Require exact-width strings. |
+| Network-dependent tests become flaky | Parse controlled JSON fixtures only. |
+| Adapter begins resolver work | Keep OCDID/geometry/model logic out. |
+| Cached source is altered | Verify SHA-256 before reuse or parse. |
+| A malformed feature disappears | Emit an error; enforce input-count parity. |
+
+## Acceptance Criteria
+
+- All seven supported geography classes have pinned layer specifications.
+- Query URLs request attributes only and deterministic GEOID ordering.
+- Error, malformed, missing-field, and truncated responses fail verification.
+- Snapshot and manifest writes are atomic.
+- Manifest checksum is verified before cache reuse or parsing.
+- Leading zeros survive fetch/cache/parse unchanged.
+- Duplicate, malformed, and component-mismatch rows become explicit errors.
+- Unit tests use controlled fixtures and no live network.
+- No model, golden-output, integration-test, OCDID, YAML, or geometry changes.
+
+## Verification and Tests
+
+Targeted commands:
+
+```bash
+uv run pytest tests/src/init_migration/test_tiger_adapter.py
+uv run ruff check src/init_migration/tiger_adapter.py \
+  tests/src/init_migration/test_tiger_adapter.py
+```
+
+Repository checks before PR review:
+
+```bash
+uv run ruff check .
+uv run pytest -m "not integration and not slow"
+```
+
+A live-source smoke check is optional and must remain separate from normal PR
+CI. It must not rewrite committed fixtures automatically.

--- a/ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-implementation.instruction.md
+++ b/ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-implementation.instruction.md
@@ -23,7 +23,7 @@ Design reference:
 
 ## Goals and Constraints
 
-- Implement the approved `fetch -> verify -> cache -> parse` boundary.
+- Implement the approved `metadata preflight -> fetch -> verify -> cache -> parse` boundary.
 - Reuse `AsyncDownloader` via dependency injection.
 - Pin the 2025 TIGERweb layer contracts.
 - Keep source codes as exact strings.
@@ -54,30 +54,37 @@ Work:
 
 - Add `TigerGeography`.
 - Add `TigerLayerSpec` and the 2025 layer catalog.
+- Pin each layer's composite-service parent group and field-width contract.
 - Add deterministic attributes-only query construction.
 - Reject unsupported vintages explicitly.
 
 Gate:
 
-- Tests cover all required layer classes and exact versioned layer IDs.
+- Tests cover all required layer classes, numeric layer IDs, parent group IDs,
+  and field-width contracts.
 - Query test proves `returnGeometry=false`, `orderByFields=GEOID`, and the
   expected field list.
 
-### Task 3 — Implement Fetch and Structural Verification
+### Task 3 — Implement Metadata Preflight, Fetch, and Structural Verification
 
 Work:
 
 - Inject the existing downloader-compatible `fetch_bytes` interface.
+- Fetch layer metadata before each record query.
+- Verify the layer ID/name, parent ACS vintage group, vintage description,
+  Query capability, record limit, required string fields, and exact widths.
 - Decode ArcGIS JSON responses.
 - Reject ArcGIS errors.
-- Reject missing or empty national `features` and malformed `attributes` structures.
+- Reject missing or empty national `features` and malformed `attributes`
+  structures.
 - Reject missing requested fields.
 - Reject transfer-limit truncation.
 
 Gate:
 
-- Unit tests cover success, source error, missing field, malformed JSON, and
-  `exceededTransferLimit=true`.
+- Unit tests cover metadata success for all seven classes; parent, description,
+  capability, record-limit, field, and width drift; source error; missing field;
+  malformed JSON; and `exceededTransferLimit=true`.
 
 ### Task 4 — Implement Atomic Cache and Manifest
 
@@ -161,7 +168,11 @@ Review gate:
 Required unit coverage:
 
 - layer catalog completeness;
-- pinned 2025 layer IDs;
+- pinned 2025 layer and parent group IDs;
+- metadata contract completeness for every query field;
+- metadata preflight order and forced metadata refresh;
+- parent-vintage, description, name, capability, record-limit, field, and width
+  drift rejection;
 - deterministic query parameters;
 - injected downloader use;
 - seven-geography fixture round trip;

--- a/ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-implementation.instruction.md
+++ b/ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-implementation.instruction.md
@@ -1,0 +1,199 @@
+---
+id: tiger-source-snapshot-adapter-implementation
+type: planning
+owner: rework
+status: draft
+last_updated: 2026-08-10
+tags: [planning, implementation, rework, census, tiger]
+issue: 135
+task: "Phase 4 — Task 4.2"
+---
+
+# TIGER Source Snapshot Adapter — Implementation Plan
+
+## Overview
+
+Deliver #135 Task 4.2 as one reviewable PR targeting
+`131-gus-pipeline-rework`. The PR adds a source adapter, controlled fixtures,
+unit tests, and these planning assets. It does not change domain models,
+integration tests, golden YAML, or downstream resolver behavior.
+
+Design reference:
+`ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-design.instruction.md`
+
+## Goals and Constraints
+
+- Implement the approved `fetch -> verify -> cache -> parse` boundary.
+- Reuse `AsyncDownloader` via dependency injection.
+- Pin the 2025 TIGERweb layer contracts.
+- Keep source codes as exact strings.
+- Fail closed on partial or unverifiable source data.
+- Keep all normal tests offline.
+- Keep the diff limited to Task 4.2.
+
+## Task Breakdown
+
+### Task 1 — Register Planning Assets
+
+Files:
+
+- `ai_tools/catalog.yaml`
+- design and implementation documents under `ai_tools/planning/`
+
+Gate:
+
+- Both new assets are cataloged with matching IDs, paths, types, and status.
+
+### Task 2 — Define Pinned Source Contracts
+
+File:
+
+- `src/init_migration/tiger_adapter.py`
+
+Work:
+
+- Add `TigerGeography`.
+- Add `TigerLayerSpec` and the 2025 layer catalog.
+- Add deterministic attributes-only query construction.
+- Reject unsupported vintages explicitly.
+
+Gate:
+
+- Tests cover all required layer classes and exact versioned layer IDs.
+- Query test proves `returnGeometry=false`, `orderByFields=GEOID`, and the
+  expected field list.
+
+### Task 3 — Implement Fetch and Structural Verification
+
+Work:
+
+- Inject the existing downloader-compatible `fetch_bytes` interface.
+- Decode ArcGIS JSON responses.
+- Reject ArcGIS errors.
+- Reject missing or empty national `features` and malformed `attributes` structures.
+- Reject missing requested fields.
+- Reject transfer-limit truncation.
+
+Gate:
+
+- Unit tests cover success, source error, missing field, malformed JSON, and
+  `exceededTransferLimit=true`.
+
+### Task 4 — Implement Atomic Cache and Manifest
+
+Work:
+
+- Store raw source bytes by vintage/geography class.
+- Write a sidecar provenance manifest.
+- Compute and validate SHA-256.
+- Reuse valid cache on HTTP 304.
+- Fail on 304 without a valid cache.
+
+Gate:
+
+- Round-trip and 304 tests pass.
+- Tampering causes a checksum failure.
+- Retrieval timestamps must be timezone-aware and serialize in UTC.
+
+### Task 5 — Implement Offline Semantic Parsing
+
+Work:
+
+- Parse exact-width string identifiers.
+- Preserve blank optional school-district type values as `None`.
+- Validate GEOID/component parity.
+- Produce normalized `TigerRecord` objects.
+- Collect malformed and duplicate rows as `TigerParseError`.
+- Preserve the input-count invariant.
+
+Gate:
+
+- All seven fixtures parse offline.
+- Leading-zero, malformed-row, duplicate-GEOID, and component-mismatch tests
+  pass.
+
+### Task 6 — Add Controlled Fixtures
+
+Files:
+
+- `tests/fixtures/tiger/README.md`
+- one synthetic ArcGIS response fixture per supported geography class
+
+Rules:
+
+- Match official field names and code widths.
+- Use synthetic names/codes where factual assertions are unnecessary.
+- Store no geometry.
+- Do not refresh fixtures from live sources automatically.
+
+Gate:
+
+- Every fixture is consumed by a parametrized unit test.
+
+### Task 7 — Validate the PR
+
+Targeted commands:
+
+```bash
+uv run pytest tests/src/init_migration/test_tiger_adapter.py
+uv run ruff check src/init_migration/tiger_adapter.py \
+  tests/src/init_migration/test_tiger_adapter.py
+```
+
+Full non-integration gate:
+
+```bash
+uv run ruff check .
+uv run pytest -m "not integration and not slow"
+```
+
+Review gate:
+
+- No files under `src/models/`, `tests/sample_output/`, or
+  `tests/integration/` changed.
+- No new package dependency added.
+- No live network required by unit tests.
+- PR base is `131-gus-pipeline-rework`.
+- PR title begins `[Rework]`.
+
+## Verification and Tests
+
+Required unit coverage:
+
+- layer catalog completeness;
+- pinned 2025 layer IDs;
+- deterministic query parameters;
+- injected downloader use;
+- seven-geography fixture round trip;
+- leading-zero preservation;
+- cache reuse after 304;
+- 304 cache miss;
+- ArcGIS error response;
+- transfer-limit truncation;
+- missing requested field;
+- malformed row reporting;
+- duplicate GEOID reporting;
+- GEOID/component mismatch;
+- checksum mismatch;
+- timezone-aware retrieval timestamp;
+- unsupported vintage.
+
+## Affected Modules
+
+```text
+ai_tools/catalog.yaml
+ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-design.instruction.md
+ai_tools/planning/2026-08-10-tiger-source-snapshot-adapter-implementation.instruction.md
+src/init_migration/tiger_adapter.py
+tests/fixtures/tiger/*
+tests/src/init_migration/test_tiger_adapter.py
+```
+
+## Follow-Ups Outside This PR
+
+- #136 consumes GUS source snapshots into `GovernmentRecord`.
+- #137 maps government records to these TIGER records and defines typed
+  resolver outcomes.
+- #137 Task 6.8 builds feature-specific TIGERweb GeoJSON URLs.
+- Future TIGER vintages add a separately reviewed pinned layer catalog and
+  source-refresh procedure.

--- a/src/init_migration/tiger_adapter.py
+++ b/src/init_migration/tiger_adapter.py
@@ -2,7 +2,7 @@
 
 The adapter keeps source acquisition separate from parsing:
 
-``fetch`` -> ``verify`` -> ``cache`` -> ``parse``
+``metadata preflight`` -> ``fetch`` -> ``verify`` -> ``cache`` -> ``parse``
 
 Only TIGERweb attributes are requested. Geometry is intentionally excluded;
 feature-specific GeoJSON URL construction belongs to the downstream resolver.
@@ -75,6 +75,7 @@ class TigerLayerSpec:
     service_name: str
     layer_id: int
     layer_name: str
+    parent_layer_id: int
     geoid_length: int
     code_field: str
     code_length: int
@@ -89,11 +90,46 @@ class TigerLayerSpec:
         )
 
     @property
+    def metadata_url(self) -> str:
+        return f"{self.layer_url}?f=json"
+
+    @property
+    def parent_layer_name(self) -> str:
+        return f"ACS {self.vintage}"
+
+    @property
     def query_fields(self) -> tuple[str, ...]:
         fields = list(self.required_fields)
         if self.ansi_field and self.ansi_field not in fields:
             fields.append(self.ansi_field)
         return tuple(fields)
+
+    @property
+    def expected_field_lengths(self) -> Mapping[str, int]:
+        lengths: dict[str, int] = {
+            "GEOID": self.geoid_length,
+            "STATE": 2,
+            "BASENAME": 100,
+            "NAME": 100,
+            "LSADC": 2,
+            "FUNCSTAT": 1,
+            "MTFCC": 5,
+            "OID": 22,
+            self.code_field: self.code_length,
+        }
+        if self.ansi_field:
+            lengths[self.ansi_field] = 8
+        if self.geography_type is TigerGeography.STATE:
+            lengths.update({"STUSAB": 2, "REGION": 1, "DIVISION": 1})
+        elif self.geography_type is TigerGeography.COUNTY_SUBDIVISION:
+            lengths["COUNTY"] = 3
+        elif self.geography_type in {
+            TigerGeography.UNIFIED_SCHOOL_DISTRICT,
+            TigerGeography.SECONDARY_SCHOOL_DISTRICT,
+            TigerGeography.ELEMENTARY_SCHOOL_DISTRICT,
+        }:
+            lengths.update({"SDTYP": 1, "LOGRADE": 2, "HIGRADE": 2})
+        return lengths
 
 
 _COMMON_FIELDS = (
@@ -107,8 +143,9 @@ _COMMON_FIELDS = (
     "OID",
 )
 
-# These layer IDs are under the versioned ``ACS 2025`` groups in TIGERweb,
-# not the mutable current-vintage layers at the top of each MapServer.
+# These numeric layer IDs currently sit under the ``ACS 2025`` groups in
+# TIGERweb's composite services. ``fetch`` verifies the live layer metadata
+# before downloading records so a future service reordering fails closed.
 TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
     TigerGeography.STATE: TigerLayerSpec(
         geography_type=TigerGeography.STATE,
@@ -116,6 +153,7 @@ TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
         service_name="State_County",
         layer_id=18,
         layer_name="States",
+        parent_layer_id=17,
         geoid_length=2,
         code_field="STATE",
         code_length=2,
@@ -129,6 +167,7 @@ TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
         service_name="State_County",
         layer_id=19,
         layer_name="Counties",
+        parent_layer_id=17,
         geoid_length=5,
         code_field="COUNTY",
         code_length=3,
@@ -141,6 +180,7 @@ TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
         service_name="Places_CouSub_ConCity_SubMCD",
         layer_id=11,
         layer_name="Incorporated Places",
+        parent_layer_id=6,
         geoid_length=7,
         code_field="PLACE",
         code_length=5,
@@ -153,6 +193,7 @@ TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
         service_name="Places_CouSub_ConCity_SubMCD",
         layer_id=8,
         layer_name="County Subdivisions",
+        parent_layer_id=6,
         geoid_length=10,
         code_field="COUSUB",
         code_length=5,
@@ -166,6 +207,7 @@ TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
         service_name="School",
         layer_id=5,
         layer_name="Unified School Districts",
+        parent_layer_id=4,
         geoid_length=7,
         code_field="SDUNI",
         code_length=5,
@@ -178,6 +220,7 @@ TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
         service_name="School",
         layer_id=6,
         layer_name="Secondary School Districts",
+        parent_layer_id=4,
         geoid_length=7,
         code_field="SDSEC",
         code_length=5,
@@ -190,6 +233,7 @@ TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
         service_name="School",
         layer_id=7,
         layer_name="Elementary School Districts",
+        parent_layer_id=4,
         geoid_length=7,
         code_field="SDELM",
         code_length=5,
@@ -321,12 +365,151 @@ class TigerAdapter:
         *,
         force: bool = False,
     ) -> bytes | None:
-        """Fetch raw source bytes; ``None`` means HTTP 304/not modified."""
+        """Validate layer identity, then fetch raw source attributes."""
 
         spec = self.get_spec(geography_type)
+        metadata_payload = await downloader.fetch_bytes(
+            spec.metadata_url, force=True
+        )
+        if metadata_payload is None:
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata preflight returned no payload"
+            )
+        self.verify_layer_metadata(geography_type, metadata_payload)
         return await downloader.fetch_bytes(
             self.build_query_url(spec), force=force
         )
+
+    def verify_layer_metadata(
+        self,
+        geography_type: TigerGeography,
+        payload: bytes,
+    ) -> None:
+        """Fail closed if a numeric layer no longer matches its catalog."""
+
+        spec = self.get_spec(geography_type)
+        document = _load_json_object(payload, source_url=spec.metadata_url)
+
+        if "error" in document:
+            raise TigerSourceResponseError(
+                f"TIGERweb returned a layer metadata error for "
+                f"{geography_type.value}: {document['error']!r}"
+            )
+        if document.get("id") != spec.layer_id:
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata ID does not match the pinned catalog"
+            )
+        if document.get("name") != spec.layer_name:
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata name does not match the pinned catalog"
+            )
+        if document.get("type") != "Feature Layer":
+            raise TigerSourceResponseError(
+                "TIGERweb source must remain a Feature Layer"
+            )
+
+        parent_layer = document.get("parentLayer")
+        if not isinstance(parent_layer, Mapping):
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata must identify its parent vintage group"
+            )
+        if (
+            parent_layer.get("id") != spec.parent_layer_id
+            or parent_layer.get("name") != spec.parent_layer_name
+        ):
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata parent does not match the pinned "
+                f"{spec.parent_layer_name} group"
+            )
+
+        description = document.get("description")
+        if not isinstance(description, str):
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata description is missing"
+            )
+        normalized_description = " ".join(description.lower().split())
+        description_markers = (
+            "january 1",
+            spec.vintage.lower(),
+            "vintage",
+        )
+        if not all(
+            marker in normalized_description
+            for marker in description_markers
+        ):
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata description does not confirm the "
+                f"January 1, {spec.vintage} vintage"
+            )
+
+        capabilities = document.get("capabilities")
+        if not isinstance(capabilities, str) or "query" not in {
+            item.strip().lower() for item in capabilities.split(",")
+        }:
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata does not advertise Query capability"
+            )
+
+        max_record_count = document.get("maxRecordCount")
+        if (
+            not isinstance(max_record_count, int)
+            or isinstance(max_record_count, bool)
+            or max_record_count < self.result_record_count
+        ):
+            raise TigerSourceResponseError(
+                "TIGERweb layer maxRecordCount cannot satisfy the configured "
+                "national query"
+            )
+
+        fields = document.get("fields")
+        if not isinstance(fields, list):
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata must contain a fields list"
+            )
+        fields_by_name: dict[str, Mapping[str, Any]] = {}
+        for index, field in enumerate(fields):
+            if not isinstance(field, Mapping):
+                raise TigerSourceResponseError(
+                    f"TIGERweb layer metadata field {index} is not an object"
+                )
+            name = field.get("name")
+            if not isinstance(name, str) or not name:
+                raise TigerSourceResponseError(
+                    f"TIGERweb layer metadata field {index} has no name"
+                )
+            if name in fields_by_name:
+                raise TigerSourceResponseError(
+                    f"TIGERweb layer metadata repeats field {name!r}"
+                )
+            fields_by_name[name] = field
+
+        missing_fields = set(spec.query_fields).difference(fields_by_name)
+        if missing_fields:
+            missing_text = ", ".join(sorted(missing_fields))
+            raise TigerSourceResponseError(
+                "TIGERweb layer metadata is missing required fields: "
+                f"{missing_text}"
+            )
+
+        for name in spec.query_fields:
+            field = fields_by_name[name]
+            if field.get("type") != "esriFieldTypeString":
+                raise TigerSourceResponseError(
+                    f"TIGERweb field {name!r} must remain a string field"
+                )
+
+        for name, expected_length in spec.expected_field_lengths.items():
+            field = fields_by_name[name]
+            length = field.get("length")
+            if (
+                not isinstance(length, int)
+                or isinstance(length, bool)
+                or length != expected_length
+            ):
+                raise TigerSourceResponseError(
+                    f"TIGERweb field {name!r} must retain length "
+                    f"{expected_length}"
+                )
 
     def verify(
         self,

--- a/src/init_migration/tiger_adapter.py
+++ b/src/init_migration/tiger_adapter.py
@@ -1,0 +1,814 @@
+"""Offline-first Census TIGERweb source snapshot adapter.
+
+The adapter keeps source acquisition separate from parsing:
+
+``fetch`` -> ``verify`` -> ``cache`` -> ``parse``
+
+Only TIGERweb attributes are requested. Geometry is intentionally excluded;
+feature-specific GeoJSON URL construction belongs to the downstream resolver.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+from hashlib import sha256
+from logging import getLogger
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+from urllib.parse import urlencode
+
+logger = getLogger(__name__)
+
+TIGERWEB_BASE_URL = (
+    "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb"
+)
+DEFAULT_RESULT_RECORD_COUNT = 100_000
+MANIFEST_SCHEMA_VERSION = 1
+
+
+class TigerAdapterError(Exception):
+    """Base error for TIGER source snapshot operations."""
+
+
+class TigerSourceResponseError(TigerAdapterError):
+    """Raised when TIGERweb returns malformed, partial, or error data."""
+
+
+class TigerCacheMissError(TigerAdapterError):
+    """Raised when a conditional request has no existing cached snapshot."""
+
+
+class TigerSnapshotIntegrityError(TigerAdapterError):
+    """Raised when a cached snapshot does not match its manifest checksum."""
+
+
+class BytesFetcher(Protocol):
+    """Minimal interface implemented by ``AsyncDownloader``."""
+
+    async def fetch_bytes(
+        self, url: str, *, force: bool = False
+    ) -> bytes | None: ...
+
+
+class TigerGeography(StrEnum):
+    """TIGER geography classes required by the GUS rework."""
+
+    STATE = "state"
+    COUNTY = "county"
+    PLACE = "place"
+    COUNTY_SUBDIVISION = "county_subdivision"
+    UNIFIED_SCHOOL_DISTRICT = "unified_school_district"
+    SECONDARY_SCHOOL_DISTRICT = "secondary_school_district"
+    ELEMENTARY_SCHOOL_DISTRICT = "elementary_school_district"
+
+
+@dataclass(frozen=True)
+class TigerLayerSpec:
+    """Pinned TIGERweb layer contract for one geography class."""
+
+    geography_type: TigerGeography
+    vintage: str
+    service_name: str
+    layer_id: int
+    layer_name: str
+    geoid_length: int
+    code_field: str
+    code_length: int
+    required_fields: tuple[str, ...]
+    ansi_field: str | None = None
+
+    @property
+    def layer_url(self) -> str:
+        return (
+            f"{TIGERWEB_BASE_URL}/{self.service_name}/MapServer/"
+            f"{self.layer_id}"
+        )
+
+    @property
+    def query_fields(self) -> tuple[str, ...]:
+        fields = list(self.required_fields)
+        if self.ansi_field and self.ansi_field not in fields:
+            fields.append(self.ansi_field)
+        return tuple(fields)
+
+
+_COMMON_FIELDS = (
+    "GEOID",
+    "STATE",
+    "BASENAME",
+    "NAME",
+    "LSADC",
+    "FUNCSTAT",
+    "MTFCC",
+    "OID",
+)
+
+# These layer IDs are under the versioned ``ACS 2025`` groups in TIGERweb,
+# not the mutable current-vintage layers at the top of each MapServer.
+TIGER_LAYERS_2025: Mapping[TigerGeography, TigerLayerSpec] = {
+    TigerGeography.STATE: TigerLayerSpec(
+        geography_type=TigerGeography.STATE,
+        vintage="2025",
+        service_name="State_County",
+        layer_id=18,
+        layer_name="States",
+        geoid_length=2,
+        code_field="STATE",
+        code_length=2,
+        required_fields=_COMMON_FIELDS
+        + ("STATENS", "STUSAB", "REGION", "DIVISION"),
+        ansi_field="STATENS",
+    ),
+    TigerGeography.COUNTY: TigerLayerSpec(
+        geography_type=TigerGeography.COUNTY,
+        vintage="2025",
+        service_name="State_County",
+        layer_id=19,
+        layer_name="Counties",
+        geoid_length=5,
+        code_field="COUNTY",
+        code_length=3,
+        required_fields=_COMMON_FIELDS + ("COUNTY", "COUNTYNS"),
+        ansi_field="COUNTYNS",
+    ),
+    TigerGeography.PLACE: TigerLayerSpec(
+        geography_type=TigerGeography.PLACE,
+        vintage="2025",
+        service_name="Places_CouSub_ConCity_SubMCD",
+        layer_id=11,
+        layer_name="Incorporated Places",
+        geoid_length=7,
+        code_field="PLACE",
+        code_length=5,
+        required_fields=_COMMON_FIELDS + ("PLACE", "PLACENS"),
+        ansi_field="PLACENS",
+    ),
+    TigerGeography.COUNTY_SUBDIVISION: TigerLayerSpec(
+        geography_type=TigerGeography.COUNTY_SUBDIVISION,
+        vintage="2025",
+        service_name="Places_CouSub_ConCity_SubMCD",
+        layer_id=8,
+        layer_name="County Subdivisions",
+        geoid_length=10,
+        code_field="COUSUB",
+        code_length=5,
+        required_fields=_COMMON_FIELDS
+        + ("COUNTY", "COUSUB", "COUSUBNS"),
+        ansi_field="COUSUBNS",
+    ),
+    TigerGeography.UNIFIED_SCHOOL_DISTRICT: TigerLayerSpec(
+        geography_type=TigerGeography.UNIFIED_SCHOOL_DISTRICT,
+        vintage="2025",
+        service_name="School",
+        layer_id=5,
+        layer_name="Unified School Districts",
+        geoid_length=7,
+        code_field="SDUNI",
+        code_length=5,
+        required_fields=_COMMON_FIELDS
+        + ("SDUNI", "SDTYP", "LOGRADE", "HIGRADE"),
+    ),
+    TigerGeography.SECONDARY_SCHOOL_DISTRICT: TigerLayerSpec(
+        geography_type=TigerGeography.SECONDARY_SCHOOL_DISTRICT,
+        vintage="2025",
+        service_name="School",
+        layer_id=6,
+        layer_name="Secondary School Districts",
+        geoid_length=7,
+        code_field="SDSEC",
+        code_length=5,
+        required_fields=_COMMON_FIELDS
+        + ("SDSEC", "SDTYP", "LOGRADE", "HIGRADE"),
+    ),
+    TigerGeography.ELEMENTARY_SCHOOL_DISTRICT: TigerLayerSpec(
+        geography_type=TigerGeography.ELEMENTARY_SCHOOL_DISTRICT,
+        vintage="2025",
+        service_name="School",
+        layer_id=7,
+        layer_name="Elementary School Districts",
+        geoid_length=7,
+        code_field="SDELM",
+        code_length=5,
+        required_fields=_COMMON_FIELDS
+        + ("SDELM", "SDTYP", "LOGRADE", "HIGRADE"),
+    ),
+}
+
+_LAYER_CATALOGS: Mapping[
+    str, Mapping[TigerGeography, TigerLayerSpec]
+] = {"2025": TIGER_LAYERS_2025}
+
+
+@dataclass(frozen=True)
+class VerifiedTigerSnapshot:
+    """Structurally verified source response ready to cache."""
+
+    spec: TigerLayerSpec
+    source_url: str
+    payload: bytes
+    record_count: int
+
+
+@dataclass(frozen=True)
+class TigerSnapshotMetadata:
+    """Sidecar metadata for one cached TIGER source response."""
+
+    geography_type: TigerGeography
+    vintage: str
+    service_name: str
+    layer_id: int
+    layer_name: str
+    source_url: str
+    retrieved_at: str
+    sha256: str
+    record_count: int
+    snapshot_path: Path
+    manifest_path: Path
+
+
+@dataclass(frozen=True)
+class TigerRecord:
+    """Normalized geography attributes parsed from a TIGER snapshot."""
+
+    geography_type: TigerGeography
+    geoid: str
+    name: str
+    basename: str
+    state_fips: str
+    state_abbreviation: str | None
+    county_fips: str | None
+    place_fips: str | None
+    county_subdivision_fips: str | None
+    school_district_fips: str | None
+    ansi_code: str | None
+    lsad_code: str
+    functional_status: str
+    mtfcc: str
+    source_oid: str
+    school_district_type: str | None
+    low_grade: str | None
+    high_grade: str | None
+
+
+@dataclass(frozen=True)
+class TigerParseError:
+    """One source row that could not be normalized."""
+
+    feature_index: int
+    geoid: str | None
+    message: str
+    attributes: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class TigerParseResult:
+    """Parsed records plus explicit errors; no input row disappears."""
+
+    records: tuple[TigerRecord, ...]
+    errors: tuple[TigerParseError, ...]
+
+    @property
+    def input_count(self) -> int:
+        return len(self.records) + len(self.errors)
+
+
+class TigerAdapter:
+    """Fetch, verify, cache, and parse pinned TIGERweb snapshots."""
+
+    def __init__(
+        self,
+        cache_root: str | os.PathLike[str],
+        *,
+        vintage: str = "2025",
+        result_record_count: int = DEFAULT_RESULT_RECORD_COUNT,
+    ) -> None:
+        if vintage not in _LAYER_CATALOGS:
+            supported = ", ".join(sorted(_LAYER_CATALOGS))
+            raise ValueError(
+                f"Unsupported TIGER vintage {vintage!r}; supported: {supported}"
+            )
+        if result_record_count < 1:
+            raise ValueError("result_record_count must be positive")
+
+        self.cache_root = Path(cache_root)
+        self.vintage = vintage
+        self.result_record_count = result_record_count
+
+    def get_spec(self, geography_type: TigerGeography) -> TigerLayerSpec:
+        return _LAYER_CATALOGS[self.vintage][geography_type]
+
+    def build_query_url(self, spec: TigerLayerSpec) -> str:
+        """Build the national attributes-only query for a pinned layer."""
+
+        params = (
+            ("where", "1=1"),
+            ("outFields", ",".join(spec.query_fields)),
+            ("returnGeometry", "false"),
+            ("orderByFields", "GEOID"),
+            ("resultRecordCount", str(self.result_record_count)),
+            ("f", "json"),
+        )
+        return f"{spec.layer_url}/query?{urlencode(params)}"
+
+    async def fetch(
+        self,
+        downloader: BytesFetcher,
+        geography_type: TigerGeography,
+        *,
+        force: bool = False,
+    ) -> bytes | None:
+        """Fetch raw source bytes; ``None`` means HTTP 304/not modified."""
+
+        spec = self.get_spec(geography_type)
+        return await downloader.fetch_bytes(
+            self.build_query_url(spec), force=force
+        )
+
+    def verify(
+        self,
+        geography_type: TigerGeography,
+        payload: bytes,
+    ) -> VerifiedTigerSnapshot:
+        """Verify ArcGIS response shape and guard against partial snapshots."""
+
+        spec = self.get_spec(geography_type)
+        source_url = self.build_query_url(spec)
+        document = _load_json_object(payload, source_url=source_url)
+
+        if "error" in document:
+            raise TigerSourceResponseError(
+                f"TIGERweb returned an error for {geography_type.value}: "
+                f"{document['error']!r}"
+            )
+        if document.get("exceededTransferLimit") is True:
+            raise TigerSourceResponseError(
+                "TIGERweb response exceeded its transfer limit; refusing "
+                "to cache a partial snapshot"
+            )
+
+        features = document.get("features")
+        if not isinstance(features, list):
+            raise TigerSourceResponseError(
+                "TIGERweb response must contain a features list"
+            )
+        if not features:
+            raise TigerSourceResponseError(
+                "TIGERweb national layer response contained no features"
+            )
+
+        expected_fields = set(spec.query_fields)
+        for index, feature in enumerate(features):
+            if not isinstance(feature, Mapping):
+                raise TigerSourceResponseError(
+                    f"Feature {index} is not an object"
+                )
+            attributes = feature.get("attributes")
+            if not isinstance(attributes, Mapping):
+                raise TigerSourceResponseError(
+                    f"Feature {index} has no attributes object"
+                )
+            missing = expected_fields.difference(attributes)
+            if missing:
+                missing_text = ", ".join(sorted(missing))
+                raise TigerSourceResponseError(
+                    f"Feature {index} is missing requested fields: "
+                    f"{missing_text}"
+                )
+
+        return VerifiedTigerSnapshot(
+            spec=spec,
+            source_url=source_url,
+            payload=payload,
+            record_count=len(features),
+        )
+
+    def cache(
+        self,
+        snapshot: VerifiedTigerSnapshot,
+        *,
+        retrieved_at: datetime | None = None,
+    ) -> TigerSnapshotMetadata:
+        """Atomically cache raw bytes plus a provenance/checksum manifest."""
+
+        snapshot_path, manifest_path = self._cache_paths(
+            snapshot.spec.geography_type
+        )
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        digest = sha256(snapshot.payload).hexdigest()
+        timestamp = _format_utc(retrieved_at or datetime.now(timezone.utc))
+
+        _atomic_write_bytes(snapshot_path, snapshot.payload)
+        manifest = {
+            "schema_version": MANIFEST_SCHEMA_VERSION,
+            "dataset": "census_tigerweb",
+            "geography_type": snapshot.spec.geography_type.value,
+            "vintage": snapshot.spec.vintage,
+            "service_name": snapshot.spec.service_name,
+            "layer_id": snapshot.spec.layer_id,
+            "layer_name": snapshot.spec.layer_name,
+            "source_url": snapshot.source_url,
+            "retrieved_at": timestamp,
+            "sha256": digest,
+            "record_count": snapshot.record_count,
+            "snapshot_file": snapshot_path.name,
+        }
+        _atomic_write_text(
+            manifest_path,
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        )
+
+        metadata = TigerSnapshotMetadata(
+            geography_type=snapshot.spec.geography_type,
+            vintage=snapshot.spec.vintage,
+            service_name=snapshot.spec.service_name,
+            layer_id=snapshot.spec.layer_id,
+            layer_name=snapshot.spec.layer_name,
+            source_url=snapshot.source_url,
+            retrieved_at=timestamp,
+            sha256=digest,
+            record_count=snapshot.record_count,
+            snapshot_path=snapshot_path,
+            manifest_path=manifest_path,
+        )
+        logger.info(
+            "Cached TIGER source snapshot",
+            extra={
+                "geography_type": metadata.geography_type.value,
+                "vintage": metadata.vintage,
+                "record_count": metadata.record_count,
+                "sha256": metadata.sha256,
+            },
+        )
+        return metadata
+
+    def load_cached_metadata(
+        self, geography_type: TigerGeography
+    ) -> TigerSnapshotMetadata:
+        """Load and integrity-check a cached snapshot manifest."""
+
+        spec = self.get_spec(geography_type)
+        snapshot_path, manifest_path = self._cache_paths(geography_type)
+        if not snapshot_path.is_file() or not manifest_path.is_file():
+            raise TigerCacheMissError(
+                f"No cached TIGER snapshot for {geography_type.value} "
+                f"vintage {self.vintage}"
+            )
+
+        manifest = _load_json_object(
+            manifest_path.read_bytes(), source_url=str(manifest_path)
+        )
+        schema_version = _required_manifest_int(
+            manifest, "schema_version"
+        )
+        if schema_version != MANIFEST_SCHEMA_VERSION:
+            raise TigerSnapshotIntegrityError(
+                "Unsupported TIGER snapshot manifest schema version"
+            )
+        if manifest.get("dataset") != "census_tigerweb":
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot manifest dataset is invalid"
+            )
+        if manifest.get("geography_type") != geography_type.value:
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot manifest geography type does not match path"
+            )
+        if manifest.get("vintage") != self.vintage:
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot manifest vintage does not match adapter"
+            )
+        if manifest.get("service_name") != spec.service_name:
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot manifest service does not match catalog"
+            )
+        if manifest.get("layer_id") != spec.layer_id:
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot manifest layer does not match catalog"
+            )
+        if manifest.get("layer_name") != spec.layer_name:
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot manifest layer name does not match catalog"
+            )
+        if manifest.get("snapshot_file") != snapshot_path.name:
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot manifest filename does not match path"
+            )
+
+        payload = snapshot_path.read_bytes()
+        actual_digest = sha256(payload).hexdigest()
+        expected_digest = _required_manifest_text(manifest, "sha256")
+        if actual_digest != expected_digest:
+            raise TigerSnapshotIntegrityError(
+                f"Checksum mismatch for cached TIGER snapshot "
+                f"{snapshot_path}"
+            )
+
+        verified = self.verify(geography_type, payload)
+        source_url = _required_manifest_text(manifest, "source_url")
+        if source_url != verified.source_url:
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot source URL does not match adapter query"
+            )
+        record_count = _required_manifest_int(manifest, "record_count")
+        if record_count != verified.record_count:
+            raise TigerSnapshotIntegrityError(
+                "TIGER snapshot record count does not match manifest"
+            )
+
+        return TigerSnapshotMetadata(
+            geography_type=geography_type,
+            vintage=self.vintage,
+            service_name=spec.service_name,
+            layer_id=spec.layer_id,
+            layer_name=spec.layer_name,
+            source_url=source_url,
+            retrieved_at=_required_manifest_text(manifest, "retrieved_at"),
+            sha256=expected_digest,
+            record_count=record_count,
+            snapshot_path=snapshot_path,
+            manifest_path=manifest_path,
+        )
+
+    async def refresh(
+        self,
+        downloader: BytesFetcher,
+        geography_type: TigerGeography,
+        *,
+        force: bool = False,
+        retrieved_at: datetime | None = None,
+    ) -> TigerSnapshotMetadata:
+        """Fetch and cache a snapshot, or reuse the cache after HTTP 304."""
+
+        payload = await self.fetch(
+            downloader, geography_type, force=force
+        )
+        if payload is None:
+            return self.load_cached_metadata(geography_type)
+        verified = self.verify(geography_type, payload)
+        return self.cache(verified, retrieved_at=retrieved_at)
+
+    def parse(
+        self, geography_type: TigerGeography
+    ) -> TigerParseResult:
+        """Parse a cached snapshot into normalized records and row errors."""
+
+        metadata = self.load_cached_metadata(geography_type)
+        document = _load_json_object(
+            metadata.snapshot_path.read_bytes(),
+            source_url=str(metadata.snapshot_path),
+        )
+        features = document.get("features")
+        if not isinstance(features, list):
+            raise TigerSourceResponseError(
+                "Cached TIGER snapshot must contain a features list"
+            )
+
+        spec = self.get_spec(geography_type)
+        records: list[TigerRecord] = []
+        errors: list[TigerParseError] = []
+        seen_geoids: set[str] = set()
+
+        for index, feature in enumerate(features):
+            attributes: Mapping[str, Any]
+            if isinstance(feature, Mapping) and isinstance(
+                feature.get("attributes"), Mapping
+            ):
+                attributes = feature["attributes"]
+            else:
+                attributes = {}
+
+            geoid = _optional_text(attributes, "GEOID")
+            try:
+                record = _parse_record(spec, attributes)
+                if record.geoid in seen_geoids:
+                    raise ValueError(
+                        f"duplicate GEOID {record.geoid!r} in snapshot"
+                    )
+                seen_geoids.add(record.geoid)
+                records.append(record)
+            except (TypeError, ValueError) as exc:
+                errors.append(
+                    TigerParseError(
+                        feature_index=index,
+                        geoid=geoid,
+                        message=str(exc),
+                        attributes=dict(attributes),
+                    )
+                )
+
+        return TigerParseResult(
+            records=tuple(records),
+            errors=tuple(errors),
+        )
+
+    def _cache_paths(
+        self, geography_type: TigerGeography
+    ) -> tuple[Path, Path]:
+        directory = self.cache_root / self.vintage
+        snapshot_path = directory / f"{geography_type.value}.json"
+        manifest_path = directory / (
+            f"{geography_type.value}.manifest.json"
+        )
+        return snapshot_path, manifest_path
+
+
+def _parse_record(
+    spec: TigerLayerSpec, attributes: Mapping[str, Any]
+) -> TigerRecord:
+    geoid = _required_digits(attributes, "GEOID", spec.geoid_length)
+    state_fips = _required_digits(attributes, "STATE", 2)
+    local_code = _required_digits(
+        attributes, spec.code_field, spec.code_length
+    )
+
+    county_fips: str | None = None
+    place_fips: str | None = None
+    county_subdivision_fips: str | None = None
+    school_district_fips: str | None = None
+    state_abbreviation: str | None = None
+
+    if spec.geography_type is TigerGeography.STATE:
+        expected_geoid = state_fips
+        state_abbreviation = _required_code(attributes, "STUSAB", 2)
+    elif spec.geography_type is TigerGeography.COUNTY:
+        county_fips = local_code
+        expected_geoid = state_fips + county_fips
+    elif spec.geography_type is TigerGeography.PLACE:
+        place_fips = local_code
+        expected_geoid = state_fips + place_fips
+    elif spec.geography_type is TigerGeography.COUNTY_SUBDIVISION:
+        county_fips = _required_digits(attributes, "COUNTY", 3)
+        county_subdivision_fips = local_code
+        expected_geoid = (
+            state_fips + county_fips + county_subdivision_fips
+        )
+    else:
+        school_district_fips = local_code
+        expected_geoid = state_fips + school_district_fips
+
+    if geoid != expected_geoid:
+        raise ValueError(
+            f"GEOID {geoid!r} does not match component fields "
+            f"({expected_geoid!r})"
+        )
+
+    ansi_code = (
+        _optional_text(attributes, spec.ansi_field)
+        if spec.ansi_field
+        else None
+    )
+    is_school = spec.geography_type in {
+        TigerGeography.UNIFIED_SCHOOL_DISTRICT,
+        TigerGeography.SECONDARY_SCHOOL_DISTRICT,
+        TigerGeography.ELEMENTARY_SCHOOL_DISTRICT,
+    }
+
+    return TigerRecord(
+        geography_type=spec.geography_type,
+        geoid=geoid,
+        name=_required_text(attributes, "NAME"),
+        basename=_required_text(attributes, "BASENAME"),
+        state_fips=state_fips,
+        state_abbreviation=state_abbreviation,
+        county_fips=county_fips,
+        place_fips=place_fips,
+        county_subdivision_fips=county_subdivision_fips,
+        school_district_fips=school_district_fips,
+        ansi_code=ansi_code,
+        lsad_code=_required_digits(attributes, "LSADC", 2),
+        functional_status=_required_code(attributes, "FUNCSTAT", 1),
+        mtfcc=_required_code(attributes, "MTFCC", 5),
+        source_oid=_required_text(attributes, "OID"),
+        school_district_type=(
+            _optional_code(attributes, "SDTYP", 1)
+            if is_school
+            else None
+        ),
+        low_grade=(
+            _required_code(attributes, "LOGRADE", 2)
+            if is_school
+            else None
+        ),
+        high_grade=(
+            _required_code(attributes, "HIGRADE", 2)
+            if is_school
+            else None
+        ),
+    )
+
+
+def _load_json_object(
+    payload: bytes, *, source_url: str
+) -> dict[str, Any]:
+    try:
+        document = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise TigerSourceResponseError(
+            f"Invalid JSON from {source_url}: {exc}"
+        ) from exc
+    if not isinstance(document, dict):
+        raise TigerSourceResponseError(
+            f"JSON from {source_url} must be an object"
+        )
+    return document
+
+
+def _required_text(attributes: Mapping[str, Any], field: str) -> str:
+    value = attributes.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _optional_text(
+    attributes: Mapping[str, Any], field: str | None
+) -> str | None:
+    if field is None:
+        return None
+    value = attributes.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _required_digits(
+    attributes: Mapping[str, Any], field: str, length: int
+) -> str:
+    value = _required_text(attributes, field)
+    if len(value) != length or not value.isdigit():
+        raise ValueError(
+            f"{field} must be an exact {length}-digit string"
+        )
+    return value
+
+
+def _required_code(
+    attributes: Mapping[str, Any], field: str, length: int
+) -> str:
+    value = _required_text(attributes, field)
+    if len(value) != length or not value.isalnum():
+        raise ValueError(
+            f"{field} must be an exact {length}-character code string"
+        )
+    return value
+
+
+def _optional_code(
+    attributes: Mapping[str, Any], field: str, length: int
+) -> str | None:
+    value = _optional_text(attributes, field)
+    if value is None:
+        return None
+    if len(value) != length or not value.isalnum():
+        raise ValueError(
+            f"{field} must be blank or an exact "
+            f"{length}-character code string"
+        )
+    return value
+
+
+def _required_manifest_text(
+    manifest: Mapping[str, Any], field: str
+) -> str:
+    value = manifest.get(field)
+    if not isinstance(value, str) or not value:
+        raise TigerSnapshotIntegrityError(
+            f"TIGER snapshot manifest field {field!r} is invalid"
+        )
+    return value
+
+
+def _required_manifest_int(
+    manifest: Mapping[str, Any], field: str
+) -> int:
+    value = manifest.get(field)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise TigerSnapshotIntegrityError(
+            f"TIGER snapshot manifest field {field!r} is invalid"
+        )
+    return value
+
+
+def _format_utc(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise ValueError("retrieved_at must be timezone-aware")
+    normalized = value.astimezone(timezone.utc)
+    return normalized.isoformat().replace("+00:00", "Z")
+
+
+def _atomic_write_bytes(path: Path, content: bytes) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_bytes(content)
+    os.replace(temporary, path)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(content, encoding="utf-8")
+    os.replace(temporary, path)

--- a/tests/fixtures/tiger/README.md
+++ b/tests/fixtures/tiger/README.md
@@ -1,0 +1,6 @@
+# TIGER adapter fixtures
+
+These are synthetic ArcGIS/TIGERweb response envelopes. They preserve the
+field names, code widths, and response shape used by the Census TIGERweb
+layers without asserting that the example names or ANSI codes are real-world
+records.

--- a/tests/fixtures/tiger/county.json
+++ b/tests/fixtures/tiger/county.json
@@ -1,0 +1,20 @@
+{
+  "exceededTransferLimit": false,
+  "features": [
+    {
+      "attributes": {
+        "BASENAME": "Example",
+        "COUNTY": "041",
+        "COUNTYNS": "00000001",
+        "FUNCSTAT": "A",
+        "GEOID": "08041",
+        "LSADC": "06",
+        "MTFCC": "G4020",
+        "NAME": "Example County",
+        "OID": "county-08041",
+        "STATE": "08"
+      }
+    }
+  ],
+  "objectIdFieldName": "OBJECTID"
+}

--- a/tests/fixtures/tiger/county_subdivision.json
+++ b/tests/fixtures/tiger/county_subdivision.json
@@ -1,0 +1,21 @@
+{
+  "exceededTransferLimit": false,
+  "features": [
+    {
+      "attributes": {
+        "BASENAME": "Example",
+        "COUNTY": "041",
+        "COUSUB": "00001",
+        "COUSUBNS": "00000001",
+        "FUNCSTAT": "A",
+        "GEOID": "0804100001",
+        "LSADC": "43",
+        "MTFCC": "G4040",
+        "NAME": "Example township",
+        "OID": "cousub-0804100001",
+        "STATE": "08"
+      }
+    }
+  ],
+  "objectIdFieldName": "OBJECTID"
+}

--- a/tests/fixtures/tiger/elementary_school_district.json
+++ b/tests/fixtures/tiger/elementary_school_district.json
@@ -1,0 +1,22 @@
+{
+  "exceededTransferLimit": false,
+  "features": [
+    {
+      "attributes": {
+        "BASENAME": "Example Elementary",
+        "FUNCSTAT": "E",
+        "GEOID": "0800003",
+        "HIGRADE": "08",
+        "LOGRADE": "PK",
+        "LSADC": "00",
+        "MTFCC": "G5400",
+        "NAME": "Example Elementary School District",
+        "OID": "sdelm-0800003",
+        "SDELM": "00003",
+        "SDTYP": "",
+        "STATE": "08"
+      }
+    }
+  ],
+  "objectIdFieldName": "OBJECTID"
+}

--- a/tests/fixtures/tiger/place.json
+++ b/tests/fixtures/tiger/place.json
@@ -1,0 +1,20 @@
+{
+  "exceededTransferLimit": false,
+  "features": [
+    {
+      "attributes": {
+        "BASENAME": "Example",
+        "FUNCSTAT": "A",
+        "GEOID": "0800001",
+        "LSADC": "25",
+        "MTFCC": "G4110",
+        "NAME": "Example city",
+        "OID": "place-0800001",
+        "PLACE": "00001",
+        "PLACENS": "00000001",
+        "STATE": "08"
+      }
+    }
+  ],
+  "objectIdFieldName": "OBJECTID"
+}

--- a/tests/fixtures/tiger/secondary_school_district.json
+++ b/tests/fixtures/tiger/secondary_school_district.json
@@ -1,0 +1,22 @@
+{
+  "exceededTransferLimit": false,
+  "features": [
+    {
+      "attributes": {
+        "BASENAME": "Example Secondary",
+        "FUNCSTAT": "E",
+        "GEOID": "0800002",
+        "HIGRADE": "12",
+        "LOGRADE": "09",
+        "LSADC": "00",
+        "MTFCC": "G5410",
+        "NAME": "Example Secondary School District",
+        "OID": "sdsec-0800002",
+        "SDSEC": "00002",
+        "SDTYP": "",
+        "STATE": "08"
+      }
+    }
+  ],
+  "objectIdFieldName": "OBJECTID"
+}

--- a/tests/fixtures/tiger/state.json
+++ b/tests/fixtures/tiger/state.json
@@ -1,0 +1,22 @@
+{
+  "exceededTransferLimit": false,
+  "features": [
+    {
+      "attributes": {
+        "BASENAME": "Colorado",
+        "DIVISION": "8",
+        "FUNCSTAT": "A",
+        "GEOID": "08",
+        "LSADC": "00",
+        "MTFCC": "G4000",
+        "NAME": "Colorado",
+        "OID": "state-08",
+        "REGION": "4",
+        "STATE": "08",
+        "STATENS": "01779779",
+        "STUSAB": "CO"
+      }
+    }
+  ],
+  "objectIdFieldName": "OBJECTID"
+}

--- a/tests/fixtures/tiger/unified_school_district.json
+++ b/tests/fixtures/tiger/unified_school_district.json
@@ -1,0 +1,22 @@
+{
+  "exceededTransferLimit": false,
+  "features": [
+    {
+      "attributes": {
+        "BASENAME": "Example Unified",
+        "FUNCSTAT": "E",
+        "GEOID": "0800001",
+        "HIGRADE": "12",
+        "LOGRADE": "PK",
+        "LSADC": "00",
+        "MTFCC": "G5420",
+        "NAME": "Example Unified School District",
+        "OID": "sduni-0800001",
+        "SDTYP": "",
+        "SDUNI": "00001",
+        "STATE": "08"
+      }
+    }
+  ],
+  "objectIdFieldName": "OBJECTID"
+}

--- a/tests/src/init_migration/test_tiger_adapter.py
+++ b/tests/src/init_migration/test_tiger_adapter.py
@@ -1,0 +1,313 @@
+"""Unit tests for the offline-first TIGER source snapshot adapter."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from src.init_migration.tiger_adapter import (
+    TIGER_LAYERS_2025,
+    TigerAdapter,
+    TigerCacheMissError,
+    TigerGeography,
+    TigerSnapshotIntegrityError,
+    TigerSourceResponseError,
+)
+
+FIXTURE_ROOT = Path(__file__).parents[2] / "fixtures" / "tiger"
+ALL_GEOGRAPHIES = tuple(TigerGeography)
+
+
+class FakeFetcher:
+    """Small ``AsyncDownloader`` stand-in for offline unit tests."""
+
+    def __init__(self, response: bytes | None) -> None:
+        self.response = response
+        self.calls: list[tuple[str, bool]] = []
+
+    async def fetch_bytes(
+        self, url: str, *, force: bool = False
+    ) -> bytes | None:
+        self.calls.append((url, force))
+        return self.response
+
+
+def fixture_bytes(geography_type: TigerGeography) -> bytes:
+    path = FIXTURE_ROOT / f"{geography_type.value}.json"
+    return path.read_bytes()
+
+
+def fixture_document(geography_type: TigerGeography) -> dict:
+    return json.loads(fixture_bytes(geography_type))
+
+
+def test_layer_catalog_covers_phase_4_scope() -> None:
+    assert set(TIGER_LAYERS_2025) == set(ALL_GEOGRAPHIES)
+
+
+def test_layer_catalog_uses_versioned_acs_2025_layers() -> None:
+    assert TIGER_LAYERS_2025[TigerGeography.STATE].layer_id == 18
+    assert TIGER_LAYERS_2025[TigerGeography.COUNTY].layer_id == 19
+    assert TIGER_LAYERS_2025[TigerGeography.PLACE].layer_id == 11
+    assert (
+        TIGER_LAYERS_2025[TigerGeography.COUNTY_SUBDIVISION].layer_id
+        == 8
+    )
+    assert (
+        TIGER_LAYERS_2025[
+            TigerGeography.UNIFIED_SCHOOL_DISTRICT
+        ].layer_id
+        == 5
+    )
+
+
+def test_query_requests_attributes_only_and_deterministic_order(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    spec = adapter.get_spec(TigerGeography.PLACE)
+
+    parsed = urlparse(adapter.build_query_url(spec))
+    query = parse_qs(parsed.query)
+
+    assert parsed.path.endswith("/MapServer/11/query")
+    assert query["where"] == ["1=1"]
+    assert query["returnGeometry"] == ["false"]
+    assert query["orderByFields"] == ["GEOID"]
+    assert query["resultRecordCount"] == ["100000"]
+    assert "GEOID" in query["outFields"][0].split(",")
+    assert "STGEOMETRY" not in query["outFields"][0].split(",")
+
+
+@pytest.mark.asyncio
+async def test_fetch_uses_injected_downloader(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    payload = fixture_bytes(TigerGeography.STATE)
+    fetcher = FakeFetcher(payload)
+
+    result = await adapter.fetch(
+        fetcher, TigerGeography.STATE, force=True
+    )
+
+    assert result == payload
+    assert len(fetcher.calls) == 1
+    assert fetcher.calls[0][1] is True
+    assert "/MapServer/18/query?" in fetcher.calls[0][0]
+
+
+@pytest.mark.parametrize("geography_type", ALL_GEOGRAPHIES)
+def test_fixture_round_trip_is_offline_and_lossless(
+    tmp_path: Path,
+    geography_type: TigerGeography,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    payload = fixture_bytes(geography_type)
+    retrieved_at = datetime(2026, 8, 10, 16, 0, tzinfo=timezone.utc)
+
+    verified = adapter.verify(geography_type, payload)
+    metadata = adapter.cache(verified, retrieved_at=retrieved_at)
+    parsed = adapter.parse(geography_type)
+
+    assert metadata.record_count == 1
+    assert metadata.retrieved_at == "2026-08-10T16:00:00Z"
+    assert metadata.snapshot_path.read_bytes() == payload
+    assert parsed.input_count == 1
+    assert len(parsed.records) == 1
+    assert parsed.errors == ()
+    assert parsed.records[0].geography_type is geography_type
+
+
+def test_parse_preserves_leading_zero_identifiers(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.COUNTY_SUBDIVISION
+    payload = fixture_bytes(geography_type)
+
+    adapter.cache(adapter.verify(geography_type, payload))
+    record = adapter.parse(geography_type).records[0]
+
+    assert record.geoid == "0804100001"
+    assert record.state_fips == "08"
+    assert record.county_fips == "041"
+    assert record.county_subdivision_fips == "00001"
+
+
+def test_parse_accepts_blank_school_district_type(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.UNIFIED_SCHOOL_DISTRICT
+    payload = fixture_bytes(geography_type)
+
+    adapter.cache(adapter.verify(geography_type, payload))
+    record = adapter.parse(geography_type).records[0]
+
+    assert record.school_district_type is None
+    assert record.low_grade == "PK"
+    assert record.high_grade == "12"
+
+
+@pytest.mark.asyncio
+async def test_refresh_reuses_integrity_checked_cache_after_304(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.STATE
+    initial = adapter.cache(
+        adapter.verify(geography_type, fixture_bytes(geography_type))
+    )
+    fetcher = FakeFetcher(None)
+
+    refreshed = await adapter.refresh(fetcher, geography_type)
+
+    assert refreshed.sha256 == initial.sha256
+    assert refreshed.record_count == initial.record_count
+    assert len(fetcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_304_without_cache_fails_closed(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+
+    with pytest.raises(TigerCacheMissError):
+        await adapter.refresh(FakeFetcher(None), TigerGeography.STATE)
+
+
+def test_verify_rejects_arcgis_error_response(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    payload = json.dumps(
+        {"error": {"code": 500, "message": "source failure"}}
+    ).encode()
+
+    with pytest.raises(TigerSourceResponseError, match="returned an error"):
+        adapter.verify(TigerGeography.STATE, payload)
+
+
+def test_verify_rejects_partial_transfer(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    document = fixture_document(TigerGeography.STATE)
+    document["exceededTransferLimit"] = True
+
+    with pytest.raises(
+        TigerSourceResponseError, match="partial snapshot"
+    ):
+        adapter.verify(
+            TigerGeography.STATE, json.dumps(document).encode()
+        )
+
+
+def test_verify_rejects_empty_national_layer(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    document = fixture_document(TigerGeography.STATE)
+    document["features"] = []
+
+    with pytest.raises(
+        TigerSourceResponseError, match="contained no features"
+    ):
+        adapter.verify(
+            TigerGeography.STATE, json.dumps(document).encode()
+        )
+
+
+def test_verify_rejects_missing_requested_field(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    document = fixture_document(TigerGeography.PLACE)
+    del document["features"][0]["attributes"]["PLACE"]
+
+    with pytest.raises(
+        TigerSourceResponseError, match="missing requested fields: PLACE"
+    ):
+        adapter.verify(
+            TigerGeography.PLACE, json.dumps(document).encode()
+        )
+
+
+def test_parse_reports_bad_row_instead_of_dropping_it(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.PLACE
+    document = fixture_document(geography_type)
+    malformed = dict(document["features"][0]["attributes"])
+    malformed["GEOID"] = 800001
+    document["features"].append({"attributes": malformed})
+    payload = json.dumps(document).encode()
+
+    adapter.cache(adapter.verify(geography_type, payload))
+    result = adapter.parse(geography_type)
+
+    assert result.input_count == 2
+    assert len(result.records) == 1
+    assert len(result.errors) == 1
+    assert result.errors[0].feature_index == 1
+    assert "GEOID must be a non-empty string" in result.errors[0].message
+
+
+def test_parse_reports_duplicate_geoid(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.COUNTY
+    document = fixture_document(geography_type)
+    duplicate = dict(document["features"][0]["attributes"])
+    document["features"].append({"attributes": duplicate})
+    payload = json.dumps(document).encode()
+
+    adapter.cache(adapter.verify(geography_type, payload))
+    result = adapter.parse(geography_type)
+
+    assert result.input_count == 2
+    assert len(result.records) == 1
+    assert len(result.errors) == 1
+    assert "duplicate GEOID" in result.errors[0].message
+
+
+def test_parse_reports_component_geoid_mismatch(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.COUNTY
+    document = fixture_document(geography_type)
+    document["features"][0]["attributes"]["COUNTY"] = "042"
+    payload = json.dumps(document).encode()
+
+    adapter.cache(adapter.verify(geography_type, payload))
+    result = adapter.parse(geography_type)
+
+    assert result.records == ()
+    assert len(result.errors) == 1
+    assert "does not match component fields" in result.errors[0].message
+
+
+def test_cached_snapshot_checksum_mismatch_fails_closed(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.STATE
+    metadata = adapter.cache(
+        adapter.verify(geography_type, fixture_bytes(geography_type))
+    )
+    metadata.snapshot_path.write_bytes(
+        metadata.snapshot_path.read_bytes() + b"\n"
+    )
+
+    with pytest.raises(
+        TigerSnapshotIntegrityError, match="Checksum mismatch"
+    ):
+        adapter.load_cached_metadata(geography_type)
+
+
+def test_cache_requires_timezone_aware_retrieval_time(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    verified = adapter.verify(
+        TigerGeography.STATE, fixture_bytes(TigerGeography.STATE)
+    )
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        adapter.cache(verified, retrieved_at=datetime(2026, 8, 10))
+
+
+def test_unsupported_vintage_is_explicit(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unsupported TIGER vintage"):
+        TigerAdapter(tmp_path, vintage="2024")

--- a/tests/src/init_migration/test_tiger_adapter.py
+++ b/tests/src/init_migration/test_tiger_adapter.py
@@ -14,6 +14,7 @@ from src.init_migration.tiger_adapter import (
     TigerAdapter,
     TigerCacheMissError,
     TigerGeography,
+    TigerLayerSpec,
     TigerSnapshotIntegrityError,
     TigerSourceResponseError,
 )
@@ -25,15 +26,17 @@ ALL_GEOGRAPHIES = tuple(TigerGeography)
 class FakeFetcher:
     """Small ``AsyncDownloader`` stand-in for offline unit tests."""
 
-    def __init__(self, response: bytes | None) -> None:
-        self.response = response
+    def __init__(self, *responses: bytes | None) -> None:
+        self.responses = list(responses)
         self.calls: list[tuple[str, bool]] = []
 
     async def fetch_bytes(
         self, url: str, *, force: bool = False
     ) -> bytes | None:
         self.calls.append((url, force))
-        return self.response
+        if not self.responses:
+            raise AssertionError("FakeFetcher received an unexpected request")
+        return self.responses.pop(0)
 
 
 def fixture_bytes(geography_type: TigerGeography) -> bytes:
@@ -43,6 +46,35 @@ def fixture_bytes(geography_type: TigerGeography) -> bytes:
 
 def fixture_document(geography_type: TigerGeography) -> dict:
     return json.loads(fixture_bytes(geography_type))
+
+
+def layer_metadata_document(spec: TigerLayerSpec) -> dict:
+    return {
+        "id": spec.layer_id,
+        "name": spec.layer_name,
+        "type": "Feature Layer",
+        "description": (
+            f"{spec.layer_name}; January 1, {spec.vintage} vintage"
+        ),
+        "parentLayer": {
+            "id": spec.parent_layer_id,
+            "name": spec.parent_layer_name,
+        },
+        "capabilities": "Map,Query,Data",
+        "maxRecordCount": 100_000,
+        "fields": [
+            {
+                "name": name,
+                "type": "esriFieldTypeString",
+                "length": length,
+            }
+            for name, length in spec.expected_field_lengths.items()
+        ],
+    }
+
+
+def layer_metadata_bytes(spec: TigerLayerSpec) -> bytes:
+    return json.dumps(layer_metadata_document(spec)).encode()
 
 
 def test_layer_catalog_covers_phase_4_scope() -> None:
@@ -63,6 +95,23 @@ def test_layer_catalog_uses_versioned_acs_2025_layers() -> None:
         ].layer_id
         == 5
     )
+    assert TIGER_LAYERS_2025[TigerGeography.STATE].parent_layer_id == 17
+    assert TIGER_LAYERS_2025[TigerGeography.PLACE].parent_layer_id == 6
+    assert (
+        TIGER_LAYERS_2025[
+            TigerGeography.UNIFIED_SCHOOL_DISTRICT
+        ].parent_layer_id
+        == 4
+    )
+
+
+@pytest.mark.parametrize("geography_type", ALL_GEOGRAPHIES)
+def test_layer_catalog_defines_widths_for_every_query_field(
+    geography_type: TigerGeography,
+) -> None:
+    spec = TIGER_LAYERS_2025[geography_type]
+
+    assert set(spec.expected_field_lengths) == set(spec.query_fields)
 
 
 def test_query_requests_attributes_only_and_deterministic_order(
@@ -83,20 +132,162 @@ def test_query_requests_attributes_only_and_deterministic_order(
     assert "STGEOMETRY" not in query["outFields"][0].split(",")
 
 
-@pytest.mark.asyncio
-async def test_fetch_uses_injected_downloader(tmp_path: Path) -> None:
+@pytest.mark.parametrize("geography_type", ALL_GEOGRAPHIES)
+def test_layer_metadata_preflight_accepts_catalog_contract(
+    tmp_path: Path,
+    geography_type: TigerGeography,
+) -> None:
     adapter = TigerAdapter(tmp_path)
-    payload = fixture_bytes(TigerGeography.STATE)
-    fetcher = FakeFetcher(payload)
+    spec = adapter.get_spec(geography_type)
 
-    result = await adapter.fetch(
-        fetcher, TigerGeography.STATE, force=True
+    adapter.verify_layer_metadata(
+        geography_type, layer_metadata_bytes(spec)
     )
 
+
+@pytest.mark.asyncio
+async def test_fetch_preflights_metadata_before_query(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.STATE
+    spec = adapter.get_spec(geography_type)
+    payload = fixture_bytes(geography_type)
+    fetcher = FakeFetcher(layer_metadata_bytes(spec), payload)
+
+    result = await adapter.fetch(fetcher, geography_type)
+
     assert result == payload
-    assert len(fetcher.calls) == 1
-    assert fetcher.calls[0][1] is True
-    assert "/MapServer/18/query?" in fetcher.calls[0][0]
+    assert fetcher.calls == [
+        (spec.metadata_url, True),
+        (adapter.build_query_url(spec), False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_missing_metadata_payload(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+
+    with pytest.raises(
+        TigerSourceResponseError, match="metadata preflight returned no payload"
+    ):
+        await adapter.fetch(FakeFetcher(None), TigerGeography.STATE)
+
+
+def test_layer_metadata_rejects_wrong_parent_vintage(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.STATE
+    spec = adapter.get_spec(geography_type)
+    document = layer_metadata_document(spec)
+    document["parentLayer"] = {"id": 35, "name": "ACS 2024"}
+
+    with pytest.raises(
+        TigerSourceResponseError, match="parent does not match"
+    ):
+        adapter.verify_layer_metadata(
+            geography_type, json.dumps(document).encode()
+        )
+
+
+def test_layer_metadata_rejects_description_vintage_drift(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.PLACE
+    spec = adapter.get_spec(geography_type)
+    document = layer_metadata_document(spec)
+    document["description"] = "Incorporated Places; January 1, 2024 vintage"
+
+    with pytest.raises(
+        TigerSourceResponseError, match="does not confirm"
+    ):
+        adapter.verify_layer_metadata(
+            geography_type, json.dumps(document).encode()
+        )
+
+
+def test_layer_metadata_rejects_name_drift(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.COUNTY
+    spec = adapter.get_spec(geography_type)
+    document = layer_metadata_document(spec)
+    document["name"] = "County Subdivisions"
+
+    with pytest.raises(
+        TigerSourceResponseError, match="name does not match"
+    ):
+        adapter.verify_layer_metadata(
+            geography_type, json.dumps(document).encode()
+        )
+
+
+def test_layer_metadata_rejects_missing_query_capability(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.STATE
+    spec = adapter.get_spec(geography_type)
+    document = layer_metadata_document(spec)
+    document["capabilities"] = "Map,Data"
+
+    with pytest.raises(
+        TigerSourceResponseError, match="Query capability"
+    ):
+        adapter.verify_layer_metadata(
+            geography_type, json.dumps(document).encode()
+        )
+
+
+def test_layer_metadata_rejects_small_record_limit(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.STATE
+    spec = adapter.get_spec(geography_type)
+    document = layer_metadata_document(spec)
+    document["maxRecordCount"] = 2_000
+
+    with pytest.raises(
+        TigerSourceResponseError, match="maxRecordCount"
+    ):
+        adapter.verify_layer_metadata(
+            geography_type, json.dumps(document).encode()
+        )
+
+
+def test_layer_metadata_rejects_missing_field(tmp_path: Path) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.PLACE
+    spec = adapter.get_spec(geography_type)
+    document = layer_metadata_document(spec)
+    document["fields"] = [
+        field for field in document["fields"] if field["name"] != "PLACE"
+    ]
+
+    with pytest.raises(
+        TigerSourceResponseError, match="missing required fields: PLACE"
+    ):
+        adapter.verify_layer_metadata(
+            geography_type, json.dumps(document).encode()
+        )
+
+
+def test_layer_metadata_rejects_identifier_width_drift(
+    tmp_path: Path,
+) -> None:
+    adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.UNIFIED_SCHOOL_DISTRICT
+    spec = adapter.get_spec(geography_type)
+    document = layer_metadata_document(spec)
+    geoid_field = next(
+        field for field in document["fields"] if field["name"] == "GEOID"
+    )
+    geoid_field["length"] = 8
+
+    with pytest.raises(
+        TigerSourceResponseError, match="GEOID.*retain length 7"
+    ):
+        adapter.verify_layer_metadata(
+            geography_type, json.dumps(document).encode()
+        )
 
 
 @pytest.mark.parametrize("geography_type", ALL_GEOGRAPHIES)
@@ -154,16 +345,17 @@ async def test_refresh_reuses_integrity_checked_cache_after_304(
 ) -> None:
     adapter = TigerAdapter(tmp_path)
     geography_type = TigerGeography.STATE
+    spec = adapter.get_spec(geography_type)
     initial = adapter.cache(
         adapter.verify(geography_type, fixture_bytes(geography_type))
     )
-    fetcher = FakeFetcher(None)
+    fetcher = FakeFetcher(layer_metadata_bytes(spec), None)
 
     refreshed = await adapter.refresh(fetcher, geography_type)
 
     assert refreshed.sha256 == initial.sha256
     assert refreshed.record_count == initial.record_count
-    assert len(fetcher.calls) == 1
+    assert len(fetcher.calls) == 2
 
 
 @pytest.mark.asyncio
@@ -171,9 +363,13 @@ async def test_refresh_304_without_cache_fails_closed(
     tmp_path: Path,
 ) -> None:
     adapter = TigerAdapter(tmp_path)
+    geography_type = TigerGeography.STATE
+    spec = adapter.get_spec(geography_type)
 
     with pytest.raises(TigerCacheMissError):
-        await adapter.refresh(FakeFetcher(None), TigerGeography.STATE)
+        await adapter.refresh(
+            FakeFetcher(layer_metadata_bytes(spec), None), geography_type
+        )
 
 
 def test_verify_rejects_arcgis_error_response(tmp_path: Path) -> None:


### PR DESCRIPTION
## Change Type

* [ ] YAML data change (divisions / jurisdictions)
* [x] Code change

## Summary

Adds an offline-first Census TIGER source snapshot adapter for #135, Task 4.2.

The adapter implements a separated:

`metadata preflight → fetch → verify → cache → parse`

lifecycle and supports:

* states
* counties
* incorporated places
* county subdivisions
* unified school districts
* secondary school districts
* elementary school districts

The implementation preserves leading-zero Census identifiers and snapshot provenance while allowing normal parsing and unit tests to run entirely from local fixtures.

---

### Code Change

**Linked Issue:** Refs #135 — Task 4.2

**What changed:**

* Added a reusable `TigerAdapter`.
* Reused the existing `AsyncDownloader` network boundary.
* Added pinned vintage-specific TIGERweb layer definitions.
* Added a live layer-metadata preflight that verifies layer ID, name, ACS 2025 parent group, vintage description, Query capability, maximum record count, required fields, and identifier widths before downloading records.
* Added attribute-only TIGERweb queries without polygon downloads.
* Preserved GEOIDs, FIPS codes, and school-district identifiers as strings.
* Added source URL, vintage, retrieval timestamp, layer identity, record count, and SHA-256 snapshot metadata.
* Added verification for malformed responses, ArcGIS errors, empty datasets, truncated transfers, duplicate GEOIDs, invalid caches, and unexpected TIGERweb layer drift.
* Added structured row-level parsing errors so records are not silently discarded.
* Added offline fixtures and targeted unit tests.
* Added the required design and implementation planning documents.

**Scope boundaries:**

This PR does not:

* modify `src/models/`
* generate OCDIDs
* generate Division or Jurisdiction YAML
* implement the Government Units-to-geography resolver
* generate the final PID-to-Division lookup
* construct feature-specific GeoJSON URLs
* modify `tests/sample_output/`
* modify `tests/integration/`
* add dependencies
* modify `__init__.py` files

**Validation:**

* [x] `uv sync --all-extras --frozen`
* [x] `uv run pytest tests/src/init_migration/test_tiger_adapter.py`

  * 47 passed
* [x] `uv run ruff check src/init_migration/tiger_adapter.py tests/src/init_migration/test_tiger_adapter.py`

  * All checks passed
* [x] `uv run ruff check .`

  * All checks passed
* [x] `uv run pytest -m "not integration and not slow"`

  * 196 passed, 14 deselected

**Follow-up:**

The parsed TIGER source records are intended to feed the Government-to-Geography Resolver in #137. A later implementation slice will combine Government Units records with these TIGER records to produce the reproducible PID-to-Division relationship.
