### PR TITLE
[Rework] Phase 4.3 — Add OCD master source snapshot adapter

### DIFF
--- a/docs/rework/ocd_master_source_contract.md
+++ b/docs/rework/ocd_master_source_contract.md
@@ -1,0 +1,137 @@
+# OCD Division ID Master Source Contract
+
+## Purpose
+
+This document defines the source boundary for Issue #135, Task 4.3. The adapter
+uses the Open Civic Data United States division ID master only to answer an
+exact membership question:
+
+> Does this complete `ocd-division/...` identifier exist in the pinned master?
+
+Nearest-ID results are optional review aids. They are never accepted as matches
+and never generate, repair, normalize, or quarantine an OCD ID.
+
+## Pinned Source
+
+| Field | Value |
+|---|---|
+| Repository | `opencivicdata/ocd-division-ids` |
+| Repository revision | `a52719a15852fc8c8418194016c16657591930ad` |
+| Source path | `identifiers/country-us.csv` |
+| Git blob SHA-1 | `bca1de20902adabb89961d08e68e0400d41dde50` |
+| Source format | UTF-8 CSV |
+
+The raw download URL contains the full repository revision. Normal development
+and tests use a controlled local fixture and perform no network requests.
+
+## Exact Header Contract
+
+The pinned CSV header is:
+
+```text
+id
+name
+sameAs
+sameAsNote
+validThrough
+census_geoid
+census_geoid_12
+census_geoid_14
+openstates_district
+placeholder_id
+sch_dist_stateid
+state_id
+validFrom
+```
+
+The adapter rejects missing, reordered, renamed, or additional columns. It
+preserves the original CSV bytes unchanged in the cache. The source record API
+emits only the exact identifier, display name, and source row needed for this
+membership boundary; the unmodified cached snapshot remains authoritative for
+all other source fields.
+
+## Lifecycle Contract
+
+### Fetch
+
+- Use the repository's existing asynchronous downloader boundary.
+- Fetch the revision-pinned raw URL.
+- Treat a conditional `304 Not Modified` result as `None` and reuse only a
+  complete, integrity-checked cache.
+
+### Verify
+
+Before caching or parsing, require:
+
+- non-empty source bytes within the configured size limit;
+- no NUL bytes and valid UTF-8;
+- the pinned Git blob identity when configured;
+- the exact header sequence above;
+- at least one data row;
+- the exact expected column count on every row;
+- a non-empty identifier and display name;
+- no surrounding whitespace on identifiers;
+- every identifier to parse through `OCDIdParsed.parse_ocdid()`;
+- `ocd-division` identifiers only; and
+- no duplicate identifiers.
+
+Verification is fail-closed. A malformed or partial source is not cached and
+cannot produce an acceptance index.
+
+### Cache
+
+Cache the original source bytes unchanged beside an atomic JSON manifest that
+records:
+
+- repository, revision, source path, and revision-pinned URL;
+- retrieval timestamp in UTC;
+- SHA-256 and Git blob SHA-1 identities;
+- byte size and data-row count;
+- exact headers; and
+- local source and manifest paths.
+
+Loading a cache repeats source verification and compares all integrity fields.
+
+### Parse
+
+Parsing emits immutable source records with:
+
+- exact OCD division ID;
+- source display name; and
+- one-based CSV source row number.
+
+No normalization or inferred hierarchy is introduced.
+
+## Membership and Suggestions
+
+### Acceptance
+
+`exact_lookup()` and `contains()` validate the candidate with
+`OCDIdParsed.parse_ocdid()` and then perform literal full-ID membership. A
+valid negative remains negative.
+
+### Review-only suggestions
+
+`suggest_for_review()`:
+
+- runs only for valid, non-member division IDs;
+- searches only siblings with the same segment type under the candidate's
+  immediate parent;
+- returns an explicit `review_only = True` marker; and
+- never changes `contains()` or `exact_lookup()`.
+
+No score threshold is an acceptance threshold.
+
+## Scope Exclusions
+
+This task does not:
+
+- generate OCD IDs;
+- implement the Phase 7 rule engine;
+- implement Phase 8 validation or quarantine decisions;
+- normalize Census Government Units records;
+- resolve governments to TIGER geography;
+- write DuckDB state, orphan tables, Division YAML, or Jurisdiction YAML;
+- modify `src/models/`, `tests/sample_output/`, `tests/integration/`, workflows,
+  dependencies, or package `__init__.py` files; or
+- make network requests during normal tests.

--- a/src/init_migration/ocd_master_adapter.py
+++ b/src/init_migration/ocd_master_adapter.py
@@ -1,0 +1,727 @@
+"""Offline-first adapter for the Open Civic Data US division ID master.
+
+The adapter keeps source acquisition separate from downstream OCDID generation:
+
+``fetch`` -> ``verify`` -> ``cache`` -> ``parse``
+
+Exact membership is the only acceptance rule. Optional nearest-ID suggestions are
+explicitly review-only diagnostics and never change a negative membership result.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha1, sha256
+from pathlib import Path
+from types import MappingProxyType
+from typing import Iterable, Literal, Mapping, Protocol
+
+from rapidfuzz import fuzz, process
+
+from src.models.ocdid import OCDIdParsed
+
+MANIFEST_SCHEMA_VERSION = 1
+MAX_SOURCE_BYTES = 96 * 1024 * 1024
+OCD_MASTER_HEADERS = (
+    "id",
+    "name",
+    "sameAs",
+    "sameAsNote",
+    "validThrough",
+    "census_geoid",
+    "census_geoid_12",
+    "census_geoid_14",
+    "openstates_district",
+    "placeholder_id",
+    "sch_dist_stateid",
+    "state_id",
+    "validFrom",
+)
+
+
+class OCDMasterAdapterError(Exception):
+    """Base error for OCD master source snapshot operations."""
+
+
+class OCDMasterSourceError(OCDMasterAdapterError):
+    """Raised when source bytes do not satisfy the pinned CSV contract."""
+
+
+class OCDMasterCacheMissError(OCDMasterAdapterError):
+    """Raised when no complete cached snapshot exists."""
+
+
+class OCDMasterSnapshotIntegrityError(OCDMasterAdapterError):
+    """Raised when cached bytes or metadata fail integrity validation."""
+
+
+class BytesFetcher(Protocol):
+    """Minimal network interface implemented by ``AsyncDownloader``."""
+
+    async def fetch_bytes(
+        self, url: str, *, force: bool = False
+    ) -> bytes | None: ...
+
+
+@dataclass(frozen=True)
+class OCDMasterReleaseSpec:
+    """Pinned source contract for one OCD division ID master revision."""
+
+    repository: str
+    revision: str
+    source_path: str
+    source_url: str
+    expected_git_blob_sha1: str | None
+    headers: tuple[str, ...] = OCD_MASTER_HEADERS
+
+
+OCD_MASTER_RELEASE = OCDMasterReleaseSpec(
+    repository="opencivicdata/ocd-division-ids",
+    revision="a52719a15852fc8c8418194016c16657591930ad",
+    source_path="identifiers/country-us.csv",
+    source_url=(
+        "https://raw.githubusercontent.com/opencivicdata/ocd-division-ids/"
+        "a52719a15852fc8c8418194016c16657591930ad/"
+        "identifiers/country-us.csv"
+    ),
+    expected_git_blob_sha1="bca1de20902adabb89961d08e68e0400d41dde50",
+)
+
+
+@dataclass(frozen=True)
+class VerifiedOCDMasterSnapshot:
+    """Verified source bytes ready to cache or parse."""
+
+    spec: OCDMasterReleaseSpec
+    payload: bytes
+    source_sha256: str
+    source_git_blob_sha1: str
+    source_size: int
+    data_row_count: int
+
+
+@dataclass(frozen=True)
+class OCDMasterSnapshotMetadata:
+    """Provenance and integrity metadata for one cached source snapshot."""
+
+    source_repository: str
+    source_revision: str
+    source_repository_path: str
+    source_url: str
+    retrieved_at: str
+    source_sha256: str
+    source_git_blob_sha1: str
+    source_size: int
+    data_row_count: int
+    headers: tuple[str, ...]
+    cache_path: Path
+    manifest_path: Path
+
+
+@dataclass(frozen=True)
+class OCDMasterSourceRecord:
+    """One exact source membership record with row provenance."""
+
+    ocdid: str
+    name: str
+    source_row_number: int
+
+
+@dataclass(frozen=True)
+class OCDMasterParseResult:
+    """Validated source records emitted from one pinned snapshot."""
+
+    source_repository: str
+    source_revision: str
+    source_url: str
+    source_sha256: str
+    records: tuple[OCDMasterSourceRecord, ...]
+
+    @property
+    def record_count(self) -> int:
+        return len(self.records)
+
+
+@dataclass(frozen=True)
+class OCDMasterSuggestion:
+    """A nearest-ID diagnostic that requires human review."""
+
+    candidate_ocdid: str
+    suggested_ocdid: str
+    suggested_name: str
+    score: float
+    review_only: Literal[True] = True
+
+
+class OCDMasterIndex:
+    """Immutable exact-membership index over validated OCD master records."""
+
+    def __init__(self, records: Iterable[OCDMasterSourceRecord]) -> None:
+        by_ocdid: dict[str, OCDMasterSourceRecord] = {}
+        choices_by_scope: dict[tuple[str, str], list[tuple[str, str]]] = {}
+
+        for record in records:
+            parsed = _parse_division_ocdid(record.ocdid)
+            if record.ocdid in by_ocdid:
+                raise ValueError(f"Duplicate OCD ID in index: {record.ocdid}")
+            by_ocdid[record.ocdid] = record
+            parent, segment_type, leaf = _suggestion_scope(parsed)
+            choices_by_scope.setdefault((parent, segment_type), []).append(
+                (leaf, record.ocdid)
+            )
+
+        frozen_choices = {
+            scope: tuple(sorted(choices, key=lambda item: item[1]))
+            for scope, choices in choices_by_scope.items()
+        }
+        self._by_ocdid: Mapping[str, OCDMasterSourceRecord] = MappingProxyType(
+            by_ocdid
+        )
+        self._choices_by_scope: Mapping[
+            tuple[str, str], tuple[tuple[str, str], ...]
+        ] = MappingProxyType(frozen_choices)
+
+    def __len__(self) -> int:
+        return len(self._by_ocdid)
+
+    def exact_lookup(self, candidate_ocdid: str) -> OCDMasterSourceRecord | None:
+        """Return the literal exact match, or ``None`` for a valid miss."""
+
+        _parse_division_ocdid(candidate_ocdid)
+        return self._by_ocdid.get(candidate_ocdid)
+
+    def contains(self, candidate_ocdid: str) -> bool:
+        """Return whether a valid candidate is an exact source member."""
+
+        return self.exact_lookup(candidate_ocdid) is not None
+
+    def suggest_for_review(
+        self,
+        candidate_ocdid: str,
+        *,
+        limit: int = 5,
+        score_cutoff: float = 70.0,
+    ) -> tuple[OCDMasterSuggestion, ...]:
+        """Return same-parent nearest IDs without changing exact membership.
+
+        Suggestions are intentionally limited to siblings with the same segment
+        type under the candidate's immediate parent. They are diagnostics for a
+        person to inspect; callers
+        must never promote a suggestion into an accepted match automatically.
+        """
+
+        parsed_candidate = _parse_division_ocdid(candidate_ocdid)
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
+            raise ValueError("limit must be a positive integer")
+        if not 0 <= score_cutoff <= 100:
+            raise ValueError("score_cutoff must be between 0 and 100")
+        if candidate_ocdid in self._by_ocdid:
+            return ()
+
+        parent, segment_type, candidate_leaf = _suggestion_scope(parsed_candidate)
+        scoped_choices = self._choices_by_scope.get((parent, segment_type), ())
+        if not scoped_choices:
+            return ()
+
+        leaf_choices = tuple(leaf for leaf, _ in scoped_choices)
+        matches = process.extract(
+            candidate_leaf,
+            leaf_choices,
+            scorer=fuzz.ratio,
+            limit=limit,
+            score_cutoff=score_cutoff,
+        )
+        ordered_matches = sorted(
+            matches,
+            key=lambda item: (-item[1], scoped_choices[item[2]][1]),
+        )
+        return tuple(
+            OCDMasterSuggestion(
+                candidate_ocdid=candidate_ocdid,
+                suggested_ocdid=scoped_choices[index][1],
+                suggested_name=self._by_ocdid[scoped_choices[index][1]].name,
+                score=float(score),
+            )
+            for _, score, index in ordered_matches
+        )
+
+
+class OCDMasterAdapter:
+    """Fetch, verify, cache, and parse a pinned US OCD master snapshot."""
+
+    def __init__(
+        self,
+        cache_root: str | os.PathLike[str],
+        *,
+        release_spec: OCDMasterReleaseSpec = OCD_MASTER_RELEASE,
+        max_source_bytes: int = MAX_SOURCE_BYTES,
+    ) -> None:
+        if max_source_bytes < 1:
+            raise ValueError("max_source_bytes must be positive")
+        if not release_spec.revision:
+            raise ValueError("release_spec revision must not be empty")
+        if not release_spec.headers:
+            raise ValueError("release_spec headers must not be empty")
+
+        self.cache_root = Path(cache_root)
+        self.release_spec = release_spec
+        self.max_source_bytes = max_source_bytes
+
+    async def fetch(
+        self,
+        downloader: BytesFetcher,
+        *,
+        force: bool = False,
+    ) -> bytes | None:
+        """Fetch the pinned source; ``None`` means not modified."""
+
+        return await downloader.fetch_bytes(
+            self.release_spec.source_url,
+            force=force,
+        )
+
+    def verify(self, payload: bytes) -> VerifiedOCDMasterSnapshot:
+        """Verify pinned bytes, exact headers, IDs, and duplicate-free rows."""
+
+        if not payload:
+            raise OCDMasterSourceError("OCD master source is empty")
+        if len(payload) > self.max_source_bytes:
+            raise OCDMasterSourceError(
+                "OCD master source exceeds the configured size limit"
+            )
+        if b"\x00" in payload:
+            raise OCDMasterSourceError("OCD master source contains NUL bytes")
+
+        source_git_blob_sha1 = _git_blob_sha1(payload)
+        expected_blob_sha1 = self.release_spec.expected_git_blob_sha1
+        if expected_blob_sha1 and source_git_blob_sha1 != expected_blob_sha1:
+            raise OCDMasterSourceError(
+                "OCD master source does not match the pinned Git blob"
+            )
+
+        data_row_count = _scan_rows(
+            payload,
+            self.release_spec,
+            collect_records=False,
+        )[0]
+        return VerifiedOCDMasterSnapshot(
+            spec=self.release_spec,
+            payload=payload,
+            source_sha256=sha256(payload).hexdigest(),
+            source_git_blob_sha1=source_git_blob_sha1,
+            source_size=len(payload),
+            data_row_count=data_row_count,
+        )
+
+    def cache(
+        self,
+        snapshot: VerifiedOCDMasterSnapshot,
+        *,
+        retrieved_at: datetime | None = None,
+    ) -> OCDMasterSnapshotMetadata:
+        """Atomically cache original CSV bytes and a provenance manifest."""
+
+        self._require_matching_snapshot(snapshot)
+        cache_path, manifest_path = self._cache_paths()
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        timestamp = _format_utc(retrieved_at or datetime.now(timezone.utc))
+
+        _atomic_write_bytes(cache_path, snapshot.payload)
+        manifest = {
+            "schema_version": MANIFEST_SCHEMA_VERSION,
+            "dataset": "ocd_division_ids_country_us",
+            "source_repository": snapshot.spec.repository,
+            "source_revision": snapshot.spec.revision,
+            "source_repository_path": snapshot.spec.source_path,
+            "source_url": snapshot.spec.source_url,
+            "retrieved_at": timestamp,
+            "source_file": cache_path.name,
+            "source_sha256": snapshot.source_sha256,
+            "source_git_blob_sha1": snapshot.source_git_blob_sha1,
+            "source_size": snapshot.source_size,
+            "data_row_count": snapshot.data_row_count,
+            "headers": list(snapshot.spec.headers),
+        }
+        _atomic_write_text(
+            manifest_path,
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        )
+        return self._metadata_from_snapshot(
+            snapshot,
+            retrieved_at=timestamp,
+            cache_path=cache_path,
+            manifest_path=manifest_path,
+        )
+
+    def load_cached_metadata(self) -> OCDMasterSnapshotMetadata:
+        """Load and fully integrity-check a cached source and manifest."""
+
+        cache_path, manifest_path = self._cache_paths()
+        if not cache_path.is_file() or not manifest_path.is_file():
+            raise OCDMasterCacheMissError(
+                "No complete cached OCD master snapshot for revision "
+                f"{self.release_spec.revision}"
+            )
+
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise OCDMasterSnapshotIntegrityError(
+                "OCD master manifest cannot be read as UTF-8 JSON"
+            ) from exc
+        if not isinstance(manifest, dict):
+            raise OCDMasterSnapshotIntegrityError(
+                "OCD master manifest must contain a JSON object"
+            )
+
+        self._validate_manifest_contract(manifest, cache_path)
+        try:
+            payload = cache_path.read_bytes()
+        except OSError as exc:
+            raise OCDMasterSnapshotIntegrityError(
+                "Cached OCD master source cannot be read"
+            ) from exc
+
+        expected_sha256 = _required_text(manifest, "source_sha256")
+        if sha256(payload).hexdigest() != expected_sha256:
+            raise OCDMasterSnapshotIntegrityError(
+                "Checksum mismatch for cached OCD master source"
+            )
+        if len(payload) != _required_int(manifest, "source_size"):
+            raise OCDMasterSnapshotIntegrityError(
+                "Cached OCD master source size does not match manifest"
+            )
+
+        try:
+            snapshot = self.verify(payload)
+        except OCDMasterSourceError as exc:
+            raise OCDMasterSnapshotIntegrityError(
+                "Cached OCD master source no longer satisfies the pinned contract"
+            ) from exc
+
+        if snapshot.source_git_blob_sha1 != _required_text(
+            manifest, "source_git_blob_sha1"
+        ):
+            raise OCDMasterSnapshotIntegrityError(
+                "Git blob identity for cached OCD master source does not match manifest"
+            )
+        if snapshot.data_row_count != _required_int(manifest, "data_row_count"):
+            raise OCDMasterSnapshotIntegrityError(
+                "Cached OCD master row count does not match manifest"
+            )
+
+        retrieved_at = _required_utc_timestamp(manifest, "retrieved_at")
+        return self._metadata_from_snapshot(
+            snapshot,
+            retrieved_at=retrieved_at,
+            cache_path=cache_path,
+            manifest_path=manifest_path,
+        )
+
+    async def refresh(
+        self,
+        downloader: BytesFetcher,
+        *,
+        force: bool = False,
+        retrieved_at: datetime | None = None,
+    ) -> OCDMasterSnapshotMetadata:
+        """Fetch and cache a snapshot, or reuse a valid cache after HTTP 304."""
+
+        payload = await self.fetch(downloader, force=force)
+        if payload is None:
+            return self.load_cached_metadata()
+        return self.cache(self.verify(payload), retrieved_at=retrieved_at)
+
+    def parse(
+        self,
+        snapshot: VerifiedOCDMasterSnapshot,
+    ) -> OCDMasterParseResult:
+        """Parse a verified snapshot into exact source membership records."""
+
+        self._require_matching_snapshot(snapshot)
+        data_row_count, records = _scan_rows(
+            snapshot.payload,
+            snapshot.spec,
+            collect_records=True,
+        )
+        if data_row_count != snapshot.data_row_count:
+            raise OCDMasterSourceError(
+                "OCD master row count changed between verification and parsing"
+            )
+        return OCDMasterParseResult(
+            source_repository=snapshot.spec.repository,
+            source_revision=snapshot.spec.revision,
+            source_url=snapshot.spec.source_url,
+            source_sha256=snapshot.source_sha256,
+            records=records,
+        )
+
+    def parse_cached(self) -> OCDMasterParseResult:
+        """Integrity-check and parse the currently cached snapshot."""
+
+        metadata = self.load_cached_metadata()
+        snapshot = self.verify(metadata.cache_path.read_bytes())
+        return self.parse(snapshot)
+
+    @staticmethod
+    def build_index(result: OCDMasterParseResult) -> OCDMasterIndex:
+        """Build an immutable exact-membership index from parsed records."""
+
+        return OCDMasterIndex(result.records)
+
+    def _cache_paths(self) -> tuple[Path, Path]:
+        filename = Path(self.release_spec.source_path).name
+        cache_path = (
+            self.cache_root
+            / "ocd_master"
+            / self.release_spec.revision
+            / filename
+        )
+        manifest_path = cache_path.with_suffix(cache_path.suffix + ".manifest.json")
+        return cache_path, manifest_path
+
+    def _require_matching_snapshot(
+        self, snapshot: VerifiedOCDMasterSnapshot
+    ) -> None:
+        if snapshot.spec != self.release_spec:
+            raise ValueError("snapshot release spec does not match adapter")
+        if sha256(snapshot.payload).hexdigest() != snapshot.source_sha256:
+            raise OCDMasterSourceError("snapshot payload checksum is inconsistent")
+        if _git_blob_sha1(snapshot.payload) != snapshot.source_git_blob_sha1:
+            raise OCDMasterSourceError("snapshot Git blob identity is inconsistent")
+        if len(snapshot.payload) != snapshot.source_size:
+            raise OCDMasterSourceError("snapshot source size is inconsistent")
+
+    def _validate_manifest_contract(
+        self,
+        manifest: Mapping[str, object],
+        cache_path: Path,
+    ) -> None:
+        if _required_int(manifest, "schema_version") != MANIFEST_SCHEMA_VERSION:
+            raise OCDMasterSnapshotIntegrityError(
+                "Unsupported OCD master manifest schema version"
+            )
+        expected_text = {
+            "dataset": "ocd_division_ids_country_us",
+            "source_repository": self.release_spec.repository,
+            "source_revision": self.release_spec.revision,
+            "source_repository_path": self.release_spec.source_path,
+            "source_url": self.release_spec.source_url,
+            "source_file": cache_path.name,
+        }
+        for field, expected in expected_text.items():
+            if _required_text(manifest, field) != expected:
+                raise OCDMasterSnapshotIntegrityError(
+                    f"OCD master manifest {field} does not match adapter"
+                )
+
+        headers = manifest.get("headers")
+        if not isinstance(headers, list) or not all(
+            isinstance(value, str) for value in headers
+        ):
+            raise OCDMasterSnapshotIntegrityError(
+                "OCD master manifest headers are invalid"
+            )
+        if tuple(headers) != self.release_spec.headers:
+            raise OCDMasterSnapshotIntegrityError(
+                "OCD master manifest headers do not match adapter"
+            )
+
+    def _metadata_from_snapshot(
+        self,
+        snapshot: VerifiedOCDMasterSnapshot,
+        *,
+        retrieved_at: str,
+        cache_path: Path,
+        manifest_path: Path,
+    ) -> OCDMasterSnapshotMetadata:
+        return OCDMasterSnapshotMetadata(
+            source_repository=snapshot.spec.repository,
+            source_revision=snapshot.spec.revision,
+            source_repository_path=snapshot.spec.source_path,
+            source_url=snapshot.spec.source_url,
+            retrieved_at=retrieved_at,
+            source_sha256=snapshot.source_sha256,
+            source_git_blob_sha1=snapshot.source_git_blob_sha1,
+            source_size=snapshot.source_size,
+            data_row_count=snapshot.data_row_count,
+            headers=snapshot.spec.headers,
+            cache_path=cache_path,
+            manifest_path=manifest_path,
+        )
+
+
+def _scan_rows(
+    payload: bytes,
+    spec: OCDMasterReleaseSpec,
+    *,
+    collect_records: bool,
+) -> tuple[int, tuple[OCDMasterSourceRecord, ...]]:
+    try:
+        text = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise OCDMasterSourceError("OCD master source is not valid UTF-8") from exc
+
+    reader = csv.reader(io.StringIO(text, newline=""), strict=True)
+    try:
+        header = next(reader)
+    except StopIteration as exc:
+        raise OCDMasterSourceError("OCD master source has no CSV header") from exc
+    except csv.Error as exc:
+        raise OCDMasterSourceError("OCD master CSV header is malformed") from exc
+
+    if tuple(header) != spec.headers:
+        raise OCDMasterSourceError(
+            "OCD master CSV headers do not match the pinned source contract"
+        )
+
+    seen_ocdids: set[str] = set()
+    records: list[OCDMasterSourceRecord] = []
+    data_row_count = 0
+    try:
+        for source_row_number, row in enumerate(reader, start=2):
+            if len(row) != len(spec.headers):
+                raise OCDMasterSourceError(
+                    f"OCD master row {source_row_number} has {len(row)} columns; "
+                    f"expected {len(spec.headers)}"
+                )
+            ocdid = row[0]
+            name = row[1]
+            if not ocdid:
+                raise OCDMasterSourceError(
+                    f"OCD master row {source_row_number} has an empty ID"
+                )
+            if ocdid != ocdid.strip():
+                raise OCDMasterSourceError(
+                    f"OCD master row {source_row_number} has whitespace around its ID"
+                )
+            if not name.strip():
+                raise OCDMasterSourceError(
+                    f"OCD master row {source_row_number} has an empty name"
+                )
+            try:
+                _parse_division_ocdid(ocdid)
+            except Exception as exc:
+                raise OCDMasterSourceError(
+                    f"OCD master row {source_row_number} has an invalid division ID: "
+                    f"{ocdid}"
+                ) from exc
+            if ocdid in seen_ocdids:
+                raise OCDMasterSourceError(
+                    f"OCD master row {source_row_number} duplicates ID: {ocdid}"
+                )
+            seen_ocdids.add(ocdid)
+            data_row_count += 1
+            if collect_records:
+                records.append(
+                    OCDMasterSourceRecord(
+                        ocdid=ocdid,
+                        name=name,
+                        source_row_number=source_row_number,
+                    )
+                )
+    except csv.Error as exc:
+        raise OCDMasterSourceError(
+            f"OCD master CSV is malformed near line {reader.line_num}"
+        ) from exc
+
+    if data_row_count == 0:
+        raise OCDMasterSourceError("OCD master source has no data rows")
+    return data_row_count, tuple(records)
+
+
+def _parse_division_ocdid(ocdid: str) -> OCDIdParsed:
+    if not isinstance(ocdid, str) or not ocdid:
+        raise ValueError("OCD ID must be a non-empty string")
+    if ocdid != ocdid.strip():
+        raise ValueError("OCD ID must not contain surrounding whitespace")
+    parsed = OCDIdParsed.parse_ocdid(ocdid)
+    if parsed.type != "ocd-division":
+        raise ValueError("OCD master membership accepts division IDs only")
+    return parsed
+
+
+def _suggestion_scope(parsed: OCDIdParsed) -> tuple[str, str, str]:
+    parts = parsed.get_ocdid_parts()
+    if len(parts) < 2:
+        raise ValueError("OCD ID does not contain a suggestion scope")
+    leaf = parts[-1]
+    segment_type, separator, _ = leaf.partition(":")
+    if not separator or not segment_type:
+        raise ValueError("OCD ID leaf segment is invalid")
+    return "/".join(parts[:-1]), segment_type, leaf
+
+
+def _git_blob_sha1(payload: bytes) -> str:
+    digest = sha1(usedforsecurity=False)
+    digest.update(f"blob {len(payload)}\0".encode("ascii"))
+    digest.update(payload)
+    return digest.hexdigest()
+
+
+def _format_utc(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("retrieved_at must be timezone-aware")
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _required_utc_timestamp(
+    manifest: Mapping[str, object], field: str
+) -> str:
+    value = _required_text(manifest, field)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise OCDMasterSnapshotIntegrityError(
+            f"OCD master manifest {field} is not an ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise OCDMasterSnapshotIntegrityError(
+            f"OCD master manifest {field} must be timezone-aware"
+        )
+    if parsed.utcoffset().total_seconds() != 0:
+        raise OCDMasterSnapshotIntegrityError(
+            f"OCD master manifest {field} must be UTC"
+        )
+    return value
+
+
+def _required_text(manifest: Mapping[str, object], field: str) -> str:
+    value = manifest.get(field)
+    if not isinstance(value, str) or not value:
+        raise OCDMasterSnapshotIntegrityError(
+            f"OCD master manifest {field} must be non-empty text"
+        )
+    return value
+
+
+def _required_int(manifest: Mapping[str, object], field: str) -> int:
+    value = manifest.get(field)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise OCDMasterSnapshotIntegrityError(
+            f"OCD master manifest {field} must be a non-negative integer"
+        )
+    return value
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_bytes(payload)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    try:
+        temporary.write_text(text, encoding="utf-8", newline="\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/tests/fixtures/ocd_master/README.md
+++ b/tests/fixtures/ocd_master/README.md
@@ -1,0 +1,15 @@
+# OCD Master Test Fixture
+
+`mini_country_us.csv` is a controlled synthetic fixture for the OCD master
+adapter. It mirrors the pinned `country-us.csv` header contract while keeping
+normal tests offline and deterministic.
+
+The fixture intentionally includes:
+
+- country and state roots;
+- county and place divisions;
+- sibling places for same-parent suggestion tests; and
+- leading-zero-safe string handling through literal OCD IDs.
+
+It is not copied from the live source and must not be treated as production
+data.

--- a/tests/fixtures/ocd_master/mini_country_us.csv
+++ b/tests/fixtures/ocd_master/mini_country_us.csv
@@ -1,0 +1,9 @@
+id,name,sameAs,sameAsNote,validThrough,census_geoid,census_geoid_12,census_geoid_14,openstates_district,placeholder_id,sch_dist_stateid,state_id,validFrom
+ocd-division/country:us,United States,,,,,,,,,,,
+ocd-division/country:us/state:co,Colorado,,,,,,,,,,,
+ocd-division/country:us/state:co/county:el_paso,El Paso County,,,,,,,,,,,
+ocd-division/country:us/state:co/place:colorado_springs,Colorado Springs,,,,,,,,,,,
+ocd-division/country:us/state:co/place:denver,Denver,,,,,,,,,,,
+ocd-division/country:us/state:tx,Texas,,,,,,,,,,,
+ocd-division/country:us/state:tx/place:austin,Austin,,,,,,,,,,,
+ocd-division/country:us/state:tx/place:houston,Houston,,,,,,,,,,,

--- a/tests/src/init_migration/test_ocd_master_adapter.py
+++ b/tests/src/init_migration/test_ocd_master_adapter.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+import asyncio
+import csv
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from src.init_migration.ocd_master_adapter import (
+    OCD_MASTER_HEADERS,
+    OCD_MASTER_RELEASE,
+    OCDMasterAdapter,
+    OCDMasterCacheMissError,
+    OCDMasterIndex,
+    OCDMasterReleaseSpec,
+    OCDMasterSnapshotIntegrityError,
+    OCDMasterSourceError,
+    OCDMasterSourceRecord,
+)
+
+FIXTURE_PATH = (
+    Path(__file__).parents[2]
+    / "fixtures"
+    / "ocd_master"
+    / "mini_country_us.csv"
+)
+FIXED_RETRIEVED_AT = datetime(2026, 8, 16, 18, 30, tzinfo=timezone.utc)
+
+
+class FakeFetcher:
+    def __init__(self, payload: bytes | None) -> None:
+        self.payload = payload
+        self.calls: list[tuple[str, bool]] = []
+
+    async def fetch_bytes(self, url: str, *, force: bool = False) -> bytes | None:
+        self.calls.append((url, force))
+        return self.payload
+
+
+@pytest.fixture
+def fixture_payload() -> bytes:
+    return FIXTURE_PATH.read_bytes()
+
+
+@pytest.fixture
+def fixture_spec() -> OCDMasterReleaseSpec:
+    return OCDMasterReleaseSpec(
+        repository="example/ocd-division-ids",
+        revision="fixture-revision",
+        source_path="identifiers/country-us.csv",
+        source_url="https://example.invalid/fixture-revision/country-us.csv",
+        expected_git_blob_sha1=None,
+    )
+
+
+@pytest.fixture
+def adapter(
+    tmp_path: Path,
+    fixture_spec: OCDMasterReleaseSpec,
+) -> OCDMasterAdapter:
+    return OCDMasterAdapter(tmp_path, release_spec=fixture_spec)
+
+
+def _csv_payload(
+    rows: list[list[str]],
+    *,
+    headers: tuple[str, ...] = OCD_MASTER_HEADERS,
+) -> bytes:
+    from io import StringIO
+
+    output = StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerow(headers)
+    writer.writerows(rows)
+    return output.getvalue().encode("utf-8")
+
+
+def _source_row(ocdid: str, name: str) -> list[str]:
+    return [ocdid, name, *([""] * (len(OCD_MASTER_HEADERS) - 2))]
+
+
+def _verified_index(
+    adapter: OCDMasterAdapter,
+    payload: bytes,
+) -> OCDMasterIndex:
+    snapshot = adapter.verify(payload)
+    return adapter.build_index(adapter.parse(snapshot))
+
+
+def test_default_release_is_revision_pinned() -> None:
+    assert OCD_MASTER_RELEASE.revision in OCD_MASTER_RELEASE.source_url
+    assert "/master/" not in OCD_MASTER_RELEASE.source_url
+    assert OCD_MASTER_RELEASE.expected_git_blob_sha1 == (
+        "bca1de20902adabb89961d08e68e0400d41dde50"
+    )
+
+
+def test_fetch_delegates_to_existing_downloader_boundary(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    fetcher = FakeFetcher(fixture_payload)
+
+    result = asyncio.run(adapter.fetch(fetcher, force=True))
+
+    assert result == fixture_payload
+    assert fetcher.calls == [(adapter.release_spec.source_url, True)]
+
+
+def test_verify_accepts_controlled_offline_fixture(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    snapshot = adapter.verify(fixture_payload)
+
+    assert snapshot.data_row_count == 8
+    assert snapshot.source_size == len(fixture_payload)
+    assert snapshot.source_sha256 == sha256(fixture_payload).hexdigest()
+    assert len(snapshot.source_git_blob_sha1) == 40
+
+
+def test_verify_enforces_pinned_git_blob(
+    tmp_path: Path,
+    fixture_spec: OCDMasterReleaseSpec,
+    fixture_payload: bytes,
+) -> None:
+    pinned_spec = replace(fixture_spec, expected_git_blob_sha1="0" * 40)
+    pinned_adapter = OCDMasterAdapter(tmp_path, release_spec=pinned_spec)
+
+    with pytest.raises(OCDMasterSourceError, match="pinned Git blob"):
+        pinned_adapter.verify(fixture_payload)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (b"", "empty"),
+        (b"\xff\xfe", "valid UTF-8"),
+        (b"id,name\x00\n", "NUL"),
+    ],
+)
+def test_verify_rejects_invalid_source_bytes(
+    adapter: OCDMasterAdapter,
+    payload: bytes,
+    message: str,
+) -> None:
+    with pytest.raises(OCDMasterSourceError, match=message):
+        adapter.verify(payload)
+
+
+def test_verify_rejects_oversized_source(
+    tmp_path: Path,
+    fixture_spec: OCDMasterReleaseSpec,
+) -> None:
+    tiny_adapter = OCDMasterAdapter(
+        tmp_path,
+        release_spec=fixture_spec,
+        max_source_bytes=2,
+    )
+
+    with pytest.raises(OCDMasterSourceError, match="size limit"):
+        tiny_adapter.verify(b"abc")
+
+
+def test_verify_rejects_header_drift(adapter: OCDMasterAdapter) -> None:
+    changed_headers = ("ocdid", *OCD_MASTER_HEADERS[1:])
+    payload = _csv_payload(
+        [_source_row("ocd-division/country:us", "United States")],
+        headers=changed_headers,
+    )
+
+    with pytest.raises(OCDMasterSourceError, match="headers"):
+        adapter.verify(payload)
+
+
+def test_verify_rejects_source_without_data_rows(adapter: OCDMasterAdapter) -> None:
+    payload = _csv_payload([])
+
+    with pytest.raises(OCDMasterSourceError, match="no data rows"):
+        adapter.verify(payload)
+
+
+def test_verify_rejects_wrong_column_count(adapter: OCDMasterAdapter) -> None:
+    payload = _csv_payload([["ocd-division/country:us", "United States"]])
+
+    with pytest.raises(OCDMasterSourceError, match="2 columns"):
+        adapter.verify(payload)
+
+
+@pytest.mark.parametrize(
+    ("ocdid", "name", "message"),
+    [
+        ("", "Missing ID", "empty ID"),
+        ("ocd-division/country:us/state:co", "   ", "empty name"),
+        (
+            " ocd-division/country:us/state:co",
+            "Colorado",
+            "whitespace",
+        ),
+        ("not-an-ocdid", "Invalid", "invalid division ID"),
+        (
+            "ocd-jurisdiction/country:us/state:co/government",
+            "Colorado government",
+            "invalid division ID",
+        ),
+    ],
+)
+def test_verify_rejects_invalid_membership_rows(
+    adapter: OCDMasterAdapter,
+    ocdid: str,
+    name: str,
+    message: str,
+) -> None:
+    payload = _csv_payload([_source_row(ocdid, name)])
+
+    with pytest.raises(OCDMasterSourceError, match=message):
+        adapter.verify(payload)
+
+
+def test_verify_rejects_duplicate_identifiers(adapter: OCDMasterAdapter) -> None:
+    duplicate = "ocd-division/country:us/state:co"
+    payload = _csv_payload(
+        [
+            _source_row(duplicate, "Colorado"),
+            _source_row(duplicate, "Duplicate Colorado"),
+        ]
+    )
+
+    with pytest.raises(OCDMasterSourceError, match="duplicates ID"):
+        adapter.verify(payload)
+
+
+def test_parse_preserves_exact_ids_names_and_source_rows(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    result = adapter.parse(adapter.verify(fixture_payload))
+
+    assert result.record_count == 8
+    assert result.records[0] == OCDMasterSourceRecord(
+        ocdid="ocd-division/country:us",
+        name="United States",
+        source_row_number=2,
+    )
+    assert result.records[-1].source_row_number == 9
+    assert result.source_sha256 == sha256(fixture_payload).hexdigest()
+
+
+def test_exact_lookup_returns_source_record(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    index = _verified_index(adapter, fixture_payload)
+
+    match = index.exact_lookup(
+        "ocd-division/country:us/state:co/place:colorado_springs"
+    )
+
+    assert match is not None
+    assert match.name == "Colorado Springs"
+    assert index.contains(match.ocdid) is True
+
+
+def test_exact_lookup_returns_none_for_valid_negative(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    index = _verified_index(adapter, fixture_payload)
+    candidate = "ocd-division/country:us/state:co/place:missing"
+
+    assert index.exact_lookup(candidate) is None
+    assert index.contains(candidate) is False
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "not-an-ocdid",
+        " ocd-division/country:us/state:co",
+        "ocd-jurisdiction/country:us/state:co/government",
+    ],
+)
+def test_exact_lookup_rejects_malformed_or_non_division_candidates(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+    candidate: str,
+) -> None:
+    index = _verified_index(adapter, fixture_payload)
+
+    with pytest.raises(Exception):
+        index.exact_lookup(candidate)
+
+
+def test_review_suggestions_are_same_parent_and_explicitly_non_accepting(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    index = _verified_index(adapter, fixture_payload)
+    candidate = "ocd-division/country:us/state:co/place:colorado_spring"
+
+    suggestions = index.suggest_for_review(candidate, score_cutoff=60)
+
+    assert suggestions
+    assert suggestions[0].suggested_ocdid == (
+        "ocd-division/country:us/state:co/place:colorado_springs"
+    )
+    assert all(suggestion.review_only is True for suggestion in suggestions)
+    assert all("/state:co/" in suggestion.suggested_ocdid for suggestion in suggestions)
+    assert all("/place:" in suggestion.suggested_ocdid for suggestion in suggestions)
+    assert all(
+        "/state:tx/" not in suggestion.suggested_ocdid
+        for suggestion in suggestions
+    )
+    assert index.contains(candidate) is False
+    assert index.exact_lookup(candidate) is None
+
+
+def test_review_suggestions_are_empty_for_exact_member(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    index = _verified_index(adapter, fixture_payload)
+    exact = "ocd-division/country:us/state:tx/place:austin"
+
+    assert index.suggest_for_review(exact) == ()
+
+
+def test_review_suggestions_do_not_cross_missing_parent(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    index = _verified_index(adapter, fixture_payload)
+    candidate = "ocd-division/country:us/state:zz/place:austin"
+
+    assert index.suggest_for_review(candidate) == ()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"limit": 0}, "positive integer"),
+        ({"limit": True}, "positive integer"),
+        ({"score_cutoff": -1}, "between 0 and 100"),
+        ({"score_cutoff": 101}, "between 0 and 100"),
+    ],
+)
+def test_review_suggestion_controls_are_validated(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    index = _verified_index(adapter, fixture_payload)
+    candidate = "ocd-division/country:us/state:co/place:colorado_spring"
+
+    with pytest.raises(ValueError, match=message):
+        index.suggest_for_review(candidate, **kwargs)  # type: ignore[arg-type]
+
+
+def test_index_rejects_duplicate_records() -> None:
+    record = OCDMasterSourceRecord(
+        ocdid="ocd-division/country:us/state:co",
+        name="Colorado",
+        source_row_number=2,
+    )
+
+    with pytest.raises(ValueError, match="Duplicate OCD ID"):
+        OCDMasterIndex([record, record])
+
+
+def test_cache_writes_verbatim_source_and_complete_manifest(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    snapshot = adapter.verify(fixture_payload)
+
+    metadata = adapter.cache(snapshot, retrieved_at=FIXED_RETRIEVED_AT)
+    manifest = json.loads(metadata.manifest_path.read_text(encoding="utf-8"))
+
+    assert metadata.cache_path.read_bytes() == fixture_payload
+    assert metadata.retrieved_at == "2026-08-16T18:30:00Z"
+    assert manifest["source_revision"] == adapter.release_spec.revision
+    assert manifest["source_sha256"] == sha256(fixture_payload).hexdigest()
+    assert manifest["data_row_count"] == 8
+    assert tuple(manifest["headers"]) == OCD_MASTER_HEADERS
+
+
+def test_load_cached_metadata_round_trips_integrity_checked_snapshot(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    cached = adapter.cache(
+        adapter.verify(fixture_payload),
+        retrieved_at=FIXED_RETRIEVED_AT,
+    )
+
+    loaded = adapter.load_cached_metadata()
+
+    assert loaded == cached
+    assert adapter.parse_cached().record_count == 8
+
+
+def test_load_cached_metadata_detects_source_tampering(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    metadata = adapter.cache(adapter.verify(fixture_payload))
+    metadata.cache_path.write_bytes(fixture_payload + b"\n")
+
+    with pytest.raises(OCDMasterSnapshotIntegrityError, match="Checksum mismatch"):
+        adapter.load_cached_metadata()
+
+
+def test_load_cached_metadata_detects_manifest_contract_tampering(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    metadata = adapter.cache(adapter.verify(fixture_payload))
+    manifest = json.loads(metadata.manifest_path.read_text(encoding="utf-8"))
+    manifest["source_revision"] = "different-revision"
+    metadata.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(
+        OCDMasterSnapshotIntegrityError,
+        match="source_revision",
+    ):
+        adapter.load_cached_metadata()
+
+
+def test_cache_miss_is_explicit(adapter: OCDMasterAdapter) -> None:
+    with pytest.raises(OCDMasterCacheMissError, match="No complete cached"):
+        adapter.load_cached_metadata()
+
+
+def test_refresh_fetches_verifies_and_caches_new_bytes(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    fetcher = FakeFetcher(fixture_payload)
+
+    metadata = asyncio.run(
+        adapter.refresh(
+            fetcher,
+            force=True,
+            retrieved_at=FIXED_RETRIEVED_AT,
+        )
+    )
+
+    assert metadata.cache_path.read_bytes() == fixture_payload
+    assert metadata.data_row_count == 8
+    assert fetcher.calls == [(adapter.release_spec.source_url, True)]
+
+
+def test_refresh_reuses_only_a_valid_cache_after_not_modified(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    expected = adapter.cache(
+        adapter.verify(fixture_payload),
+        retrieved_at=FIXED_RETRIEVED_AT,
+    )
+    fetcher = FakeFetcher(None)
+
+    loaded = asyncio.run(adapter.refresh(fetcher))
+
+    assert loaded == expected
+
+
+def test_refresh_not_modified_without_cache_fails_closed(
+    adapter: OCDMasterAdapter,
+) -> None:
+    fetcher = FakeFetcher(None)
+
+    with pytest.raises(OCDMasterCacheMissError):
+        asyncio.run(adapter.refresh(fetcher))
+
+
+def test_cache_rejects_snapshot_from_different_release(
+    tmp_path: Path,
+    adapter: OCDMasterAdapter,
+    fixture_spec: OCDMasterReleaseSpec,
+    fixture_payload: bytes,
+) -> None:
+    snapshot = adapter.verify(fixture_payload)
+    other_adapter = OCDMasterAdapter(
+        tmp_path / "other",
+        release_spec=replace(fixture_spec, revision="different"),
+    )
+
+    with pytest.raises(ValueError, match="does not match adapter"):
+        other_adapter.cache(snapshot)
+
+
+def test_naive_retrieval_timestamp_is_rejected(
+    adapter: OCDMasterAdapter,
+    fixture_payload: bytes,
+) -> None:
+    snapshot = adapter.verify(fixture_payload)
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        adapter.cache(snapshot, retrieved_at=datetime(2026, 8, 16, 18, 30))


### PR DESCRIPTION
## Change Type

- [ ] YAML data change (divisions / jurisdictions)
- [x] Code change

## Summary

Adds an offline-first Open Civic Data master source snapshot adapter for #135, Task 4.3.

The adapter implements a separated:

`fetch → verify → cache → parse → exact lookup`

lifecycle against a revision-pinned `opencivicdata/ocd-division-ids` U.S. master CSV. Normal parsing, membership checks, and unit tests run entirely from local cached bytes or controlled fixtures.

---

### Code Change

**Linked Issue:** Refs #135 — Task 4.3

**What changed:**

- Added a reusable OCD master adapter.
- Pinned the upstream repository revision and Git blob instead of following a mutable branch URL.
- Added exact CSV header and source-blob verification.
- Added atomic original-byte caching with an integrity manifest.
- Added offline exact positive and negative membership lookup.
- Validated candidate identifiers through `OCDIdParsed.parse_ocdid()`.
- Rejected malformed rows and duplicate canonical identifiers structurally.
- Added optional nearest suggestions constrained to the same parent and segment type.
- Marked every suggestion `review_only=True`; suggestions never convert an exact negative result into an accepted match.
- Added a controlled offline fixture, source contract documentation, and targeted unit tests.

**Changed paths:**

- `docs/rework/ocd_master_source_contract.md`
- `src/init_migration/ocd_master_adapter.py`
- `tests/fixtures/ocd_master/README.md`
- `tests/fixtures/ocd_master/mini_country_us.csv`
- `tests/src/init_migration/test_ocd_master_adapter.py`

**Scope boundaries:**

This PR does not:

- modify `src/models/`
- modify the existing `OCDidMatcher`
- generate or canonicalize new OCDIDs
- allow fuzzy or nearest suggestions to establish canonical identity
- modify dependencies or workflows
- modify `__init__.py` files
- modify `tests/integration/`
- modify `tests/sample_output/`
- generate Division or Jurisdiction YAML

**Validation:**

- [x] `uv run pytest tests/src/init_migration/test_ocd_master_adapter.py`
  - 41 passed
- [x] `uv run ruff check src/init_migration/ocd_master_adapter.py tests/src/init_migration/test_ocd_master_adapter.py`
  - All checks passed
- [x] `uv run ruff check .`
  - All checks passed
- [x] `uv run pytest -m "not integration and not slow"`
  - 190 passed, 14 deselected
- [x] `git diff --cached --check`
  - Passed

**Source contract:**

See `docs/rework/ocd_master_source_contract.md` for the pinned upstream revision, blob identity, CSV schema, verification rules, cache metadata, and lookup semantics.

**Review safety:**

Exact canonical membership is the only acceptance signal. Nearest suggestions are contextual aids for human review and cannot silently canonicalize an identifier.
